### PR TITLE
Fix broken build backend and install-dev target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,8 @@ generate-data:
 	python data/generate.py
 
 install-dev:
-	@command -v uv >/dev/null 2>&1 && uv pip install -e ".[dev]" || pip install -e ".[dev]"
+	@test -d .venv || (echo "Creating .venv..." && uv venv .venv)
+	uv pip install -e ".[dev]" --python .venv/bin/python
 
 docker-up:
 	docker compose up -d

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,10 @@ watsonx = [
 
 [build-system]
 requires = ["setuptools>=68.0"]
-build-backend = "setuptools.backends._legacy:_Backend"
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+packages = []
 
 [tool.ruff]
 line-length = 120


### PR DESCRIPTION
## Summary
- Fix `setuptools.backends._legacy:_Backend` → `setuptools.build_meta` (the old path doesn't exist)
- Add `[tool.setuptools] packages = []` so setuptools doesn't try to auto-discover project dirs as Python packages
- `make install-dev` now creates a local `.venv` via `uv` instead of falling back to a broken system venv

## Test plan
- [x] `rm -rf .venv && make install-dev` completes cleanly
- [x] `.venv/bin/python -c "import pandas; print('ok')"` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)