### PR TITLE
feat: Notebook 1 — Data Warehouse pattern (7-section template)

### DIFF
--- a/notebooks/01-warehouse.ipynb
+++ b/notebooks/01-warehouse.ipynb
@@ -1,0 +1,490 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Notebook 1: The Data Warehouse Pattern\n",
+    "\n",
+    "**Data Architecture for the AI Era** | Maple Trust Bank case study\n",
+    "\n",
+    "---\n",
+    "\n",
+    "*This notebook establishes the 7-section template used by all six pattern notebooks.*"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Section 1: The Pattern in One Paragraph\n",
+    "\n",
+    "The **data warehouse** is the classic centralized, schema-on-write analytical store. Data is modelled into star or snowflake schemas — dimension tables surrounding fact tables — and optimised for analytical SQL queries. Invented independently by Bill Inmon (enterprise data warehouse, top-down) and Ralph Kimball (dimensional modelling, bottom-up) in the 1990s, the pattern remains the backbone of regulatory reporting and business intelligence at every major bank today. It is the \"boring\" pattern that actually works: stable schemas, strong consistency, audit trails, and fast aggregations over historical data. If your workload is SQL-heavy analytics over structured data with known schemas, start here."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Section 2: When You'd Use It, When You Wouldn't\n",
+    "\n",
+    "| Use when | Don't use when |\n",
+    "|----------|---------------|\n",
+    "| Stable, known schemas | Schema evolves rapidly |\n",
+    "| BI and regulatory reporting | Unstructured data / AI workloads |\n",
+    "| Strong consistency requirements | Cheap raw storage at scale |\n",
+    "| SQL-heavy analytical workloads | Sub-second OLTP |\n",
+    "| Historical trend analysis | Real-time streaming |"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## Section 3: The Setup\n",
+    "\n",
+    "We load four Parquet files into a local Postgres database and build a proper **star schema**:\n",
+    "\n",
+    "- `dim_branches` — branch dimension\n",
+    "- `dim_customers` — customer dimension\n",
+    "- `dim_accounts` — account dimension (bridge between customers and transactions)\n",
+    "- `fact_transactions` — the fact table\n",
+    "\n",
+    "**Plan A** uses Db2 Warehouse (IBM Cloud Pak for Data). **Plan B** uses the local Docker Postgres instance."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ── Configuration ─────────────────────────────────────────────────────\n",
+    "# Toggle between Plan A (Db2 Warehouse) and Plan B (local Postgres).\n",
+    "# For this lecture, Plan B is the default.\n",
+    "\n",
+    "PLAN = \"B\"  # Change to \"A\" for Db2 Warehouse on CP4D\n",
+    "\n",
+    "if PLAN == \"A\":\n",
+    "    # Plan A: Db2 Warehouse on Cloud Pak for Data\n",
+    "    DB_URL = \"db2+ibm_db://user:password@hostname:50000/BLUDB\"\n",
+    "    print(\"Using Plan A: Db2 Warehouse (update DB_URL with your CP4D credentials)\")\n",
+    "else:\n",
+    "    # Plan B: Local Postgres via docker-compose\n",
+    "    DB_URL = \"postgresql://lecture:lecture@localhost:5432/bfsi\"\n",
+    "    print(\"Using Plan B: Local Postgres (docker-compose)\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "from sqlalchemy import create_engine, text\n",
+    "from pathlib import Path\n",
+    "import json\n",
+    "\n",
+    "DATA_DIR = Path(\"../data\")\n",
+    "\n",
+    "engine = create_engine(DB_URL)\n",
+    "print(f\"Connected to: {engine.url.database}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ── Load Parquet files ────────────────────────────────────────────────\n",
+    "branches = pd.read_parquet(DATA_DIR / \"branches.parquet\")\n",
+    "customers = pd.read_parquet(DATA_DIR / \"customers.parquet\")\n",
+    "accounts = pd.read_parquet(DATA_DIR / \"accounts.parquet\")\n",
+    "transactions = pd.read_parquet(DATA_DIR / \"transactions.parquet\")\n",
+    "\n",
+    "print(f\"Loaded: {len(branches)} branches, {len(customers)} customers, \"\n",
+    "      f\"{len(accounts)} accounts, {len(transactions)} transactions\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ── Build the star schema ─────────────────────────────────────────────\n",
+    "# Create dimension and fact tables in Postgres.\n",
+    "\n",
+    "# Dimension: branches\n",
+    "branches.to_sql(\"dim_branches\", engine, if_exists=\"replace\", index=False)\n",
+    "\n",
+    "# Dimension: customers\n",
+    "customers.to_sql(\"dim_customers\", engine, if_exists=\"replace\", index=False)\n",
+    "\n",
+    "# Dimension (bridge): accounts\n",
+    "accounts.to_sql(\"dim_accounts\", engine, if_exists=\"replace\", index=False)\n",
+    "\n",
+    "# Fact: transactions\n",
+    "transactions.to_sql(\"fact_transactions\", engine, if_exists=\"replace\", index=False,\n",
+    "                    method=\"multi\", chunksize=10000)\n",
+    "\n",
+    "print(\"\\u2713 Star schema loaded: \"\n",
+    "      f\"{len(branches)} branches, {len(customers)} customers, \"\n",
+    "      f\"{len(accounts)} accounts, {len(transactions)} transactions\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## Section 4: Three Canonical Queries\n",
+    "\n",
+    "These same three business questions appear in **all six notebooks** so we can compare how each pattern handles them.\n",
+    "\n",
+    "> **Reference Architecture Swimlane:** Analytical Data Management & Storage"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Q1: Total transaction volume by branch for Q3 2024\n",
+    "\n",
+    "This is the warehouse's sweet spot — fast, clean, SQL over a star schema.\n",
+    "\n",
+    "> **Cameo cell** — run this one during Block 1 for a quick demo."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ── Q1: Branch transaction volume (Q3 2024) ──────────────────────────\n",
+    "# \ud83c\udfaf Cameo cell — run this one during Block 1 for a quick demo.\n",
+    "print(\"\ud83d\udcca Reference Architecture Swimlane: Analytical Data Management & Storage\")\n",
+    "\n",
+    "q1 = \"\"\"\n",
+    "SELECT b.name, b.region,\n",
+    "       COUNT(*)        AS txn_count,\n",
+    "       SUM(t.amount)   AS total_volume\n",
+    "FROM   fact_transactions t\n",
+    "JOIN   dim_branches b ON t.branch_id = b.branch_id\n",
+    "WHERE  t.timestamp >= '2024-07-01'\n",
+    "  AND  t.timestamp <  '2024-10-01'\n",
+    "GROUP  BY b.name, b.region\n",
+    "ORDER  BY total_volume DESC\n",
+    "\"\"\"\n",
+    "\n",
+    "df_q1 = pd.read_sql(q1, engine)\n",
+    "print(f\"\\nQ3 2024 branch transaction volume ({len(df_q1)} branches):\")\n",
+    "df_q1.head(10)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Fast, clean, one SQL statement. This is why warehouses exist."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Q2: Find all customers whose policy documents reference AML procedure X\n",
+    "\n",
+    "The warehouse can answer *structured* questions about customers and their transactions. But it cannot search inside unstructured policy documents. Let's see how far we can get."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ── Q2: Customers linked to suspicious transactions (warehouse proxy) ─\n",
+    "print(\"\ud83d\udcca Reference Architecture Swimlane: Analytical Data Management & Storage\")\n",
+    "\n",
+    "q2 = \"\"\"\n",
+    "SELECT DISTINCT c.customer_id, c.name, c.kyc_status, c.risk_score, c.segment\n",
+    "FROM   dim_customers c\n",
+    "JOIN   dim_accounts a  ON c.customer_id = a.customer_id\n",
+    "JOIN   fact_transactions t ON a.account_id = t.account_id\n",
+    "WHERE  t.transaction_type = 'wire'\n",
+    "  AND  t.amount > 10000\n",
+    "  AND  c.risk_score > 70\n",
+    "ORDER  BY c.risk_score DESC\n",
+    "LIMIT  10\n",
+    "\"\"\"\n",
+    "\n",
+    "df_q2 = pd.read_sql(q2, engine)\n",
+    "print(f\"\\nHigh-risk customers with large wire transfers ({len(df_q2)} results):\")\n",
+    "df_q2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**What we got:** Customers with high risk scores and large wire transfers — a reasonable proxy for AML-relevant activity, all from structured data.\n",
+    "\n",
+    "**What we didn't get:** The actual question was *\"find customers whose policy documents reference AML procedure X.\"* That requires searching inside PDF documents (`data/policies/MTB-POL-*.pdf`). The warehouse has no concept of full-text search over unstructured documents, embeddings, or semantic similarity.\n",
+    "\n",
+    "> **Foreshadowing:** Notebook 6 (RAG / Document Intelligence) will show how to parse, embed, and search those same policy PDFs with Docling + watsonx."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Q3: Trace the lineage of the Q3 branch summary back to source\n",
+    "\n",
+    "We can show the SQL that *produces* the aggregate, but the warehouse itself does not track data lineage. For that, you need an external catalog."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ── Q3: The SQL that produces the Q3 branch summary ──────────────────\n",
+    "print(\"\ud83d\udcca Reference Architecture Swimlane: Analytical Data Management & Storage\")\n",
+    "\n",
+    "q3_sql = \"\"\"\n",
+    "-- This is the SQL behind the Q3 branch summary.\n",
+    "-- The warehouse can PRODUCE the aggregate, but it cannot tell you\n",
+    "-- WHERE the data came from or WHAT transforms were applied.\n",
+    "\n",
+    "SELECT b.name              AS branch_name,\n",
+    "       b.region,\n",
+    "       COUNT(*)            AS txn_count,\n",
+    "       SUM(t.amount)       AS total_volume,\n",
+    "       AVG(t.amount)       AS avg_txn_amount,\n",
+    "       COUNT(DISTINCT a.account_id) AS unique_accounts\n",
+    "FROM   fact_transactions t\n",
+    "JOIN   dim_branches b  ON t.branch_id = b.branch_id\n",
+    "JOIN   dim_accounts a  ON t.account_id = a.account_id\n",
+    "WHERE  t.timestamp >= '2024-07-01'\n",
+    "  AND  t.timestamp <  '2024-10-01'\n",
+    "GROUP  BY b.name, b.region\n",
+    "ORDER  BY total_volume DESC\n",
+    "\"\"\"\n",
+    "\n",
+    "df_q3 = pd.read_sql(q3_sql, engine)\n",
+    "print(f\"\\nQ3 2024 branch summary ({len(df_q3)} branches):\")\n",
+    "df_q3.head(10)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We have the aggregate. But **where did this data come from?** What source systems? What transforms? The warehouse doesn't know — it only stores the end result.\n",
+    "\n",
+    "Let's probe the lineage graph (maintained externally by a catalog like IBM Knowledge Catalog):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ── Q3 (continued): Lineage probe ────────────────────────────────────\n",
+    "# Load the lineage graph that would be maintained by IBM Knowledge Catalog\n",
+    "\n",
+    "lineage_path = DATA_DIR / \"lineage\" / \"lineage_graph.json\"\n",
+    "with open(lineage_path) as f:\n",
+    "    lineage = json.load(f)\n",
+    "\n",
+    "# Trace lineage backward from consumed.branch_summary_quarterly\n",
+    "target = \"consumed.branch_summary_quarterly\"\n",
+    "\n",
+    "def trace_lineage(graph, target_id, depth=0):\n",
+    "    \"\"\"Recursively trace upstream lineage.\"\"\"\n",
+    "    results = []\n",
+    "    for edge in graph[\"edges\"]:\n",
+    "        if edge[\"to\"] == target_id:\n",
+    "            indent = \"  \" * depth\n",
+    "            results.append(f\"{indent}<-- {edge['from']}\")\n",
+    "            results.append(f\"{indent}    transform: {edge['transform']}\")\n",
+    "            results.extend(trace_lineage(graph, edge[\"from\"], depth + 1))\n",
+    "    return results\n",
+    "\n",
+    "print(f\"Lineage trace for: {target}\")\n",
+    "print(\"=\" * 60)\n",
+    "for line in trace_lineage(lineage, target):\n",
+    "    print(line)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Key insight:** The lineage metadata lives *outside* the warehouse — in a catalog (IBM Knowledge Catalog, Apache Atlas, etc.). The warehouse is just the query engine; it doesn't know its own provenance. This is a fundamental limitation of the pattern."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## Section 5: Where This Pattern Breaks\n",
+    "\n",
+    "Let's deliberately try something the warehouse was never designed for: storing and querying an unstructured document."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ── Attempt: Store a policy PDF in the warehouse ─────────────────────\n",
+    "print(\"\ud83d\udcca Reference Architecture Swimlane: Analytical Data Management & Storage\")\n",
+    "print(\"Attempting to store and query an unstructured policy document...\\n\")\n",
+    "\n",
+    "# Read a policy PDF as binary\n",
+    "policy_path = DATA_DIR / \"policies\" / \"MTB-POL-001.pdf\"\n",
+    "with open(policy_path, \"rb\") as f:\n",
+    "    pdf_bytes = f.read()\n",
+    "\n",
+    "print(f\"Policy file: {policy_path.name}\")\n",
+    "print(f\"Size: {len(pdf_bytes):,} bytes\")\n",
+    "print(f\"Type: binary blob\")\n",
+    "print()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ── Store as a BLOB column ───────────────────────────────────────────\n",
+    "import sqlalchemy as sa\n",
+    "\n",
+    "# Create a table with a BLOB column\n",
+    "with engine.begin() as conn:\n",
+    "    conn.execute(text(\"DROP TABLE IF EXISTS policy_documents\"))\n",
+    "    conn.execute(text(\"\"\"\n",
+    "        CREATE TABLE policy_documents (\n",
+    "            policy_id   VARCHAR(20) PRIMARY KEY,\n",
+    "            title       VARCHAR(200),\n",
+    "            pdf_content BYTEA,\n",
+    "            uploaded_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP\n",
+    "        )\n",
+    "    \"\"\"))\n",
+    "    conn.execute(\n",
+    "        text(\"INSERT INTO policy_documents (policy_id, title, pdf_content) VALUES (:id, :title, :content)\"),\n",
+    "        {\"id\": \"MTB-POL-001\", \"title\": \"AML/KYC Policy\", \"content\": pdf_bytes}\n",
+    "    )\n",
+    "\n",
+    "print(\"\\u2713 Stored PDF as BYTEA blob in policy_documents table\")\n",
+    "print()\n",
+    "print(\"Now try to QUERY the content...\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ── Try to search inside the document ────────────────────────────────\n",
+    "try:\n",
+    "    result = pd.read_sql(\n",
+    "        \"SELECT policy_id, title, LENGTH(pdf_content) as blob_size FROM policy_documents\",\n",
+    "        engine\n",
+    "    )\n",
+    "    print(\"What we CAN do:\")\n",
+    "    print(result.to_string(index=False))\n",
+    "    print()\n",
+    "    print(\"What we CANNOT do:\")\n",
+    "    print(\"  - SELECT * FROM policy_documents WHERE pdf_content CONTAINS 'AML procedure'\")\n",
+    "    print(\"  - No full-text search over binary blobs\")\n",
+    "    print(\"  - No semantic search or embedding similarity\")\n",
+    "    print(\"  - No way to extract tables, sections, or entities from the PDF\")\n",
+    "    print()\n",
+    "    print(\"The warehouse stores the bytes. It cannot understand them.\")\n",
+    "except Exception as e:\n",
+    "    print(f\"Error: {e}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Conclusion:** The warehouse excels at structured, schema-on-write analytics. The moment you need unstructured data, semantic search, or ML feature stores, you've outgrown this pattern. The PDF sits in a BLOB column — inert, unsearchable, and opaque. You need document intelligence (Notebook 6) or a lakehouse (Notebook 2) to make it useful."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## Section 6: The IBM Stack Mapping\n",
+    "\n",
+    "How the warehouse pattern maps to the IBM Software Hub / Cloud Pak for Data reference architecture:\n",
+    "\n",
+    "| Layer | IBM Product(s) |\n",
+    "|-------|---------------|\n",
+    "| **Storage** | Db2 Warehouse (SMP, MPP), Db2 on z/OS, Netezza |\n",
+    "| **Query engine** | Db2 optimizer, Presto (via watsonx.data) |\n",
+    "| **Catalog** | IBM Knowledge Catalog |\n",
+    "| **Governance** | Data Lineage, Data Quality, Business Glossary |\n",
+    "| **Reference architecture swimlane** | *Analytical Data Management & Storage* (center of diagram) |\n",
+    "\n",
+    "> **In the reference architecture diagram, this is the big blue box in the center.** Everything flows into it, everything queries from it. The warehouse is the gravitational center of the classic architecture."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## Section 7: BFSI Reality Check\n",
+    "\n",
+    "Every major Canadian bank runs Db2 on z/OS for core transaction processing. Regulatory reporting — OSFI capital adequacy, FINTRAC suspicious transaction reports, Basel III liquidity — requires stable schemas and audit trails. This is where warehouses still reign: predictable schemas, known queries, quarterly reporting cycles.\n",
+    "\n",
+    "The pain point is real, though. Banks have 15-20 year old warehouse investments that work perfectly well for BI dashboards and regulatory extracts, but they can't serve the AI workloads the business now demands: embedding generation, vector search over customer documents, unstructured data pipelines, ML feature stores. The warehouse can't store a policy PDF and let you search it semantically. It can't generate embeddings from transaction descriptions. It can't serve real-time feature vectors to a fraud model.\n",
+    "\n",
+    "**The warehouse isn't dead. It's necessary but not sufficient.** The next five notebooks will show what you add around it."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "*Next: [Notebook 2 — The Data Lakehouse Pattern](02-lakehouse.ipynb)*"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
## Summary
- Adds `notebooks/01-warehouse.ipynb` — the first of six pattern notebooks for the "Data Architecture for the AI Era" lecture
- Establishes the **7-section template** (Pattern Overview, When/When Not, Setup, Three Canonical Queries, Where It Breaks, IBM Stack Mapping, BFSI Reality Check) that all subsequent notebooks follow
- Builds a star schema (dim_branches, dim_customers, dim_accounts, fact_transactions) in Postgres from the Maple Trust Bank synthetic data
- Includes Plan A/Plan B config switching (Db2 Warehouse vs local Postgres)
- Cameo-ready: Q1 cell can be run standalone during Block 1 of the lecture

## Test plan
- [ ] Run `docker compose up -d` to start Postgres
- [ ] Run `python data/generate.py` to generate synthetic data
- [ ] Open and run all cells in `notebooks/01-warehouse.ipynb`
- [ ] Verify Q1 returns branch transaction volumes for Q3 2024
- [ ] Verify Q2 shows the warehouse limitation for unstructured document search
- [ ] Verify Q3 lineage probe traces upstream dependencies from `consumed.branch_summary_quarterly`
- [ ] Verify Section 5 demonstrates BLOB storage limitation

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)