### PR TITLE
feat: Notebooks 2-5 — Data Lake, Lakehouse, Virtualization, Data Mesh

### DIFF
--- a/notebooks/02-data-lake.ipynb
+++ b/notebooks/02-data-lake.ipynb
@@ -1,0 +1,538 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Notebook 2: The Data Lake\n",
+    "\n",
+    "**Pattern:** Raw data dumped into object storage, queried with a lightweight engine. Schema-on-read.\n",
+    "\n",
+    "**Stack:** MinIO (object storage) + DuckDB (query engine) on raw Parquet files\n",
+    "\n",
+    "**Maple Trust Bank** — synthetic BFSI data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Configuration — Plan A / Plan B\n",
+    "\n",
+    "Toggle the `USE_PLAN_A` flag below to switch between:\n",
+    "- **Plan A:** watsonx.data lakehouse (IBM Cloud)\n",
+    "- **Plan B:** Local MinIO + DuckDB (runs anywhere with Docker)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ── Configuration ──────────────────────────────────────────────────────\n",
+    "USE_PLAN_A = False  # Set True for watsonx.data lakehouse; False for local MinIO + DuckDB\n",
+    "\n",
+    "# Plan B defaults (local Docker)\n",
+    "MINIO_ENDPOINT = \"localhost:9000\"\n",
+    "MINIO_ACCESS_KEY = \"minioadmin\"\n",
+    "MINIO_SECRET_KEY = \"minioadmin\"\n",
+    "MINIO_BUCKET = \"bfsi-raw\"\n",
+    "MINIO_SECURE = False\n",
+    "\n",
+    "# Data paths\n",
+    "DATA_DIR = \"../data\"\n",
+    "LINEAGE_PATH = f\"{DATA_DIR}/lineage/lineage_graph.json\"\n",
+    "\n",
+    "if USE_PLAN_A:\n",
+    "    print(\"Plan A: watsonx.data lakehouse — configure COS credentials above.\")\n",
+    "else:\n",
+    "    print(\"Plan B: Local MinIO + DuckDB — ensure 'docker compose up minio' is running.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import duckdb\n",
+    "import pandas as pd\n",
+    "import json\n",
+    "import os\n",
+    "import pyarrow as pa\n",
+    "import pyarrow.parquet as pq\n",
+    "import tempfile\n",
+    "\n",
+    "pd.set_option(\"display.max_columns\", 20)\n",
+    "pd.set_option(\"display.width\", 120)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Section 1: The Pattern in One Paragraph\n",
+    "\n",
+    "The **data lake** is what happens when you take the Hadoop-era mantra — \"store first, ask questions later\" — and move it to object storage. Every file, every format, every team dumps their data into a single bucket. There is no schema enforcement, no data quality gate, no catalog. The promise: cheap, infinitely scalable storage where data scientists can explore freely. The reality: after three years, nobody knows what's in there, who put it there, or whether it's still valid. The lake is the architectural equivalent of a junk drawer — useful if you're the one who filled it, bewildering to everyone else. Schema-on-read means you pay the cost of understanding your data every single time you query it, not once at ingestion."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Section 2: When You'd Use It, When You Wouldn't\n",
+    "\n",
+    "| Use when | Don't use when |\n",
+    "|----------|----------------|\n",
+    "| Cheap, scalable raw storage for heterogeneous data | You need ACID transactions or consistency guarantees |\n",
+    "| ML training sets that need raw, unprocessed features | Regulatory reporting requiring schema enforcement |\n",
+    "| Exploratory analytics and data science sandboxes | Governed, auditable data pipelines |\n",
+    "| Landing zone for batch ingestion from many sources | Users expect a curated, queryable data model |\n",
+    "| You have strong data engineering to curate downstream | You have no governance team or data stewards |\n",
+    "| Archive / cold storage for compliance retention | Sub-second query latency on structured data |"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Section 3: The Setup — Load Raw Parquet into MinIO, Query with DuckDB"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Upload raw parquet files to MinIO (object storage)\n",
+    "from minio import Minio\n",
+    "from minio.error import S3Error\n",
+    "\n",
+    "client = Minio(\n",
+    "    MINIO_ENDPOINT,\n",
+    "    access_key=MINIO_ACCESS_KEY,\n",
+    "    secret_key=MINIO_SECRET_KEY,\n",
+    "    secure=MINIO_SECURE,\n",
+    ")\n",
+    "\n",
+    "# Create bucket if it doesn't exist\n",
+    "if not client.bucket_exists(MINIO_BUCKET):\n",
+    "    client.make_bucket(MINIO_BUCKET)\n",
+    "    print(f\"Created bucket: {MINIO_BUCKET}\")\n",
+    "else:\n",
+    "    print(f\"Bucket already exists: {MINIO_BUCKET}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Upload the four parquet files\n",
+    "parquet_files = [\"branches.parquet\", \"customers.parquet\", \"accounts.parquet\", \"transactions.parquet\"]\n",
+    "\n",
+    "for filename in parquet_files:\n",
+    "    filepath = os.path.join(DATA_DIR, filename)\n",
+    "    if os.path.exists(filepath):\n",
+    "        client.fput_object(MINIO_BUCKET, filename, filepath)\n",
+    "        stat = client.stat_object(MINIO_BUCKET, filename)\n",
+    "        print(f\"  Uploaded {filename} ({stat.size / 1024 / 1024:.1f} MB)\")\n",
+    "    else:\n",
+    "        print(f\"  WARNING: {filepath} not found — run 'python data/generate.py' first\")\n",
+    "\n",
+    "print(f\"\\nAll files in bucket '{MINIO_BUCKET}':\")\n",
+    "for obj in client.list_objects(MINIO_BUCKET):\n",
+    "    print(f\"  s3://{MINIO_BUCKET}/{obj.object_name}  ({obj.size / 1024 / 1024:.1f} MB)\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Connect DuckDB — query parquet files directly (schema-on-read)\n",
+    "con = duckdb.connect()\n",
+    "\n",
+    "# For local Plan B, we query the parquet files directly from disk.\n",
+    "# In Plan A (watsonx.data), you'd use Presto/Spark connectors to COS.\n",
+    "print(\"DuckDB connected — querying raw parquet files (schema-on-read)\")\n",
+    "print(\"No schema was defined. No data types were enforced. We just read what's there.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Quick schema inspection — discover what's in the lake\n",
+    "for f in parquet_files:\n",
+    "    path = os.path.join(DATA_DIR, f)\n",
+    "    result = con.execute(f\"DESCRIBE SELECT * FROM '{path}'\").fetchdf()\n",
+    "    print(f\"\\n── {f} ──\")\n",
+    "    print(result.to_string(index=False))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Row counts — what's in the lake?\n",
+    "print(\"📊 Reference Architecture Swimlane: Analytical Data Management & Storage\")\n",
+    "print(\"   (Data Lake = 'Outside Software Hub' — raw object storage)\\n\")\n",
+    "\n",
+    "for f in parquet_files:\n",
+    "    path = os.path.join(DATA_DIR, f)\n",
+    "    count = con.execute(f\"SELECT COUNT(*) FROM '{path}'\").fetchone()[0]\n",
+    "    print(f\"  {f:30s} {count:>12,} rows\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Section 4: Three Canonical Queries"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Q1: Total transaction volume by branch for Q3 2024\n",
+    "\n",
+    "DuckDB on raw parquet — works fine, but note: no schema enforcement, no data quality checks."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "q1 = con.execute(f\"\"\"\n",
+    "    SELECT\n",
+    "        t.branch_id,\n",
+    "        b.name AS branch_name,\n",
+    "        b.region,\n",
+    "        COUNT(*)           AS txn_count,\n",
+    "        SUM(t.amount)      AS total_amount,\n",
+    "        AVG(t.amount)      AS avg_amount\n",
+    "    FROM '{DATA_DIR}/transactions.parquet' t\n",
+    "    JOIN '{DATA_DIR}/branches.parquet' b ON t.branch_id = b.branch_id\n",
+    "    WHERE t.timestamp >= '2024-07-01' AND t.timestamp < '2024-10-01'\n",
+    "    GROUP BY t.branch_id, b.name, b.region\n",
+    "    ORDER BY total_amount DESC\n",
+    "\"\"\").fetchdf()\n",
+    "\n",
+    "print(\"Q1: Transaction volume by branch — Q3 2024 (top 10)\")\n",
+    "print(\"Note: This query works, but nothing prevented bad data from being in these files.\")\n",
+    "q1.head(10)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Q2: Find all customers whose policy documents reference AML procedure X\n",
+    "\n",
+    "The lake can't do this — same limitation as a warehouse, but worse. No structure, no search index, no catalog."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"Q2: Policy document search — AML procedure references\")\n",
+    "print(\"=\"*60)\n",
+    "print()\n",
+    "print(\"RESULT: Cannot be answered.\")\n",
+    "print()\n",
+    "print(\"The data lake stores raw files — parquet, CSV, JSON, PDF.\")\n",
+    "print(\"There is no full-text search engine. No document index.\")\n",
+    "print(\"No catalog to even FIND which files contain policy docs.\")\n",
+    "print()\n",
+    "print(\"In a warehouse, at least you know the schema.\")\n",
+    "print(\"In a lake, you don't even know what's in there.\")\n",
+    "print()\n",
+    "print(\"→ This is the core limitation: lakes store bytes, not knowledge.\")\n",
+    "print(\"→ Addressed in Notebook 6 (RAG) with vector search over documents.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Q3: Trace the lineage of branch_summary_quarterly back to source\n",
+    "\n",
+    "The lake has zero lineage tracking built in. We load the lineage graph separately — it's external metadata."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load the lineage graph — this is NOT part of the lake, it's external metadata\n",
+    "with open(LINEAGE_PATH) as f:\n",
+    "    lineage = json.load(f)\n",
+    "\n",
+    "print(\"Q3: Lineage for 'consumed.branch_summary_quarterly'\")\n",
+    "print(\"=\"*60)\n",
+    "print()\n",
+    "print(f\"Lineage graph: {lineage['metadata']['total_nodes']} nodes, {lineage['metadata']['total_edges']} edges\")\n",
+    "print()\n",
+    "\n",
+    "# Trace backwards from the target\n",
+    "target = \"consumed.branch_summary_quarterly\"\n",
+    "\n",
+    "def trace_lineage(target_node, edges, depth=0):\n",
+    "    \"\"\"Recursively trace lineage backwards.\"\"\"\n",
+    "    upstream = [e for e in edges if e[\"to\"] == target_node]\n",
+    "    for edge in upstream:\n",
+    "        indent = \"  \" * depth\n",
+    "        print(f\"{indent}← {edge['from']}\")\n",
+    "        print(f\"{indent}   transform: {edge['transform'][:60]}...\")\n",
+    "        trace_lineage(edge[\"from\"], edges, depth + 1)\n",
+    "\n",
+    "print(f\"Target: {target}\")\n",
+    "trace_lineage(target, lineage[\"edges\"])\n",
+    "print()\n",
+    "print(\"⚠️  This lineage graph is EXTERNAL to the lake.\")\n",
+    "print(\"   The lake itself has zero knowledge of how data flows.\")\n",
+    "print(\"   Someone had to build and maintain this graph separately.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Section 5: Where This Pattern Breaks — The Governance Gap"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Break 1: Anyone can write malformed data\n",
+    "\n",
+    "No schema enforcement means corrupt data enters silently."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create a parquet file with wrong types and missing fields\n",
+    "import pyarrow as pa\n",
+    "import pyarrow.parquet as pq\n",
+    "\n",
+    "malformed_data = pa.table({\n",
+    "    \"branch_id\": [999, 888],                       # int instead of string!\n",
+    "    \"name\": [\"Fake Branch\", None],                  # null name\n",
+    "    \"address\": [None, None],                        # all nulls\n",
+    "    # 'region' is missing entirely\n",
+    "    # 'manager_id' is missing entirely\n",
+    "    \"extra_junk_column\": [\"oops\", \"garbage\"],       # extra column\n",
+    "})\n",
+    "\n",
+    "malformed_path = os.path.join(DATA_DIR, \"branches_malformed.parquet\")\n",
+    "pq.write_table(malformed_data, malformed_path)\n",
+    "print(\"Wrote malformed parquet file to the lake.\")\n",
+    "print(\"No gate stopped us. No schema validation. No alert.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# DuckDB reads it without complaint\n",
+    "result = con.execute(f\"SELECT * FROM '{malformed_path}'\").fetchdf()\n",
+    "print(\"DuckDB reads malformed data silently:\")\n",
+    "print(result)\n",
+    "print()\n",
+    "print(\"⚠️  branch_id is integer (should be string like 'MTB-001')\")\n",
+    "print(\"⚠️  name has a NULL\")\n",
+    "print(\"⚠️  address is all NULLs\")\n",
+    "print(\"⚠️  region and manager_id are completely missing\")\n",
+    "print(\"⚠️  extra_junk_column was added — no one will know it doesn't belong\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# What happens when you UNION the malformed file with the real one?\n",
+    "try:\n",
+    "    result = con.execute(f\"\"\"\n",
+    "        SELECT branch_id, name, address FROM '{DATA_DIR}/branches.parquet'\n",
+    "        UNION ALL\n",
+    "        SELECT branch_id, name, address FROM '{malformed_path}'\n",
+    "    \"\"\").fetchdf()\n",
+    "    print(\"Union succeeded — malformed data mixed with real data:\")\n",
+    "    print(result.tail(5))\n",
+    "    print()\n",
+    "    print(\"Notice: branch_id types were silently coerced. This is how lakes become swamps.\")\n",
+    "except Exception as e:\n",
+    "    print(f\"Union failed with: {e}\")\n",
+    "    print(\"Even DuckDB noticed the types don't match — but the lake didn't prevent the write.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Break 2: No ACID — partial writes leave orphaned data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Simulate a failed multi-file write — partial data left behind\n",
+    "import tempfile\n",
+    "\n",
+    "# Suppose a pipeline writes 3 partition files, but crashes after 2\n",
+    "partial_dir = os.path.join(DATA_DIR, \"_partial_write_demo\")\n",
+    "os.makedirs(partial_dir, exist_ok=True)\n",
+    "\n",
+    "# Write partition 1 and 2 successfully\n",
+    "for i in range(2):\n",
+    "    chunk = pa.table({\n",
+    "        \"transaction_id\": [f\"TXN-PARTIAL-{i}-{j}\" for j in range(100)],\n",
+    "        \"amount\": [float(j * 10) for j in range(100)],\n",
+    "        \"status\": [\"complete\"] * 100,\n",
+    "    })\n",
+    "    pq.write_table(chunk, os.path.join(partial_dir, f\"part-{i}.parquet\"))\n",
+    "\n",
+    "# Partition 3 \"fails\" — simulate crash\n",
+    "print(\"Pipeline wrote 2 of 3 partition files, then crashed.\")\n",
+    "print(f\"Orphaned files in: {partial_dir}/\")\n",
+    "print()\n",
+    "\n",
+    "# Query the partial data — it looks like complete data\n",
+    "partial_result = con.execute(f\"SELECT COUNT(*) as rows, SUM(amount) as total FROM '{partial_dir}/*.parquet'\").fetchdf()\n",
+    "print(\"Query result on partial data (looks normal, but is INCOMPLETE):\")\n",
+    "print(partial_result)\n",
+    "print()\n",
+    "print(\"⚠️  No transaction log. No rollback. No way to know this is partial.\")\n",
+    "print(\"   A consumer will use this data assuming it's complete.\")\n",
+    "print(\"   This is why lakes need Iceberg/Delta for ACID → see Notebook 3 (Lakehouse).\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Clean up demo artifacts\n",
+    "import shutil\n",
+    "if os.path.exists(malformed_path):\n",
+    "    os.remove(malformed_path)\n",
+    "if os.path.exists(partial_dir):\n",
+    "    shutil.rmtree(partial_dir)\n",
+    "print(\"Cleaned up demo files.\")\n",
+    "print()\n",
+    "print('\"The lake is where data goes to drown.\"')\n",
+    "print('\"Without governance, it becomes a swamp.\"')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Section 6: The IBM Stack Mapping\n",
+    "\n",
+    "| Component | IBM Product | Swimlane |\n",
+    "|-----------|-------------|----------|\n",
+    "| Object Storage | IBM Cloud Object Storage (COS) | Analytical Data Management & Storage |\n",
+    "| Query Engine | watsonx.data (Presto, Spark) | Analytical Data Management & Storage |\n",
+    "| Ingestion | DataStage, Kafka (Event Streams) | Ingestion & Integration |\n",
+    "| Catalog (add-on) | IBM Knowledge Catalog | Discovery & Exploration |\n",
+    "\n",
+    "**Swimlane:** The data lake sits in the \"Outside Software Hub\" box of the reference architecture — external object storage connected through the platform."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"📊 Reference Architecture Swimlane: Analytical Data Management & Storage\")\n",
+    "print(\"   Sub-zone: 'Outside Software Hub' — external storage\")\n",
+    "print()\n",
+    "print(\"IBM Product Mapping:\")\n",
+    "print(\"  Object Storage  → IBM Cloud Object Storage (COS)\")\n",
+    "print(\"  Query Engine    → watsonx.data (Presto / Spark)\")\n",
+    "print(\"  Ingestion       → DataStage, IBM Event Streams (Kafka)\")\n",
+    "print(\"  Catalog         → IBM Knowledge Catalog (governance add-on)\")\n",
+    "print()\n",
+    "print(\"Note: The lake pattern is storage. IBM's value-add is the governance\")\n",
+    "print(\"layer (Knowledge Catalog) that prevents it from becoming a swamp.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Section 7: BFSI Reality Check\n",
+    "\n",
+    "Canadian banks universally have data lakes — usually on S3 or COS — used primarily for ML training data and data science sandboxes. The pattern works well for its intended purpose: cheap storage of raw, heterogeneous data that data scientists can explore freely. The problem appears around year three. The lake has grown to petabytes. No one knows what's in most of the buckets. The original team has moved on. Metadata is sparse or missing. Sensitive data (PII, account numbers) is scattered across files with no access controls. The compliance team can't certify what's in there for OSFI audits. One major bank discovered production ML models were training on data that had been \"deleted\" from the warehouse but still sat in the lake — a PIPEDA violation hiding in plain sight. Every bank's data lake is really a data swamp with a governance veneer."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Close DuckDB connection\n",
+    "con.close()\n",
+    "print(\"Notebook 2 complete.\")\n",
+    "print()\n",
+    "print(\"Key takeaway: The data lake is cheap, scalable, and ungoverned.\")\n",
+    "print(\"It works for raw storage but fails for anything requiring trust.\")\n",
+    "print(\"Next: Notebook 3 (Lakehouse) adds ACID, schema evolution, and time travel.\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/notebooks/03-lakehouse.ipynb
+++ b/notebooks/03-lakehouse.ipynb
@@ -1,0 +1,629 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Notebook 3: The Lakehouse\n",
+    "\n",
+    "🎯 **Live notebook** — this runs in Block 4 of the lecture (15 min).\n",
+    "\n",
+    "**Pattern:** Open table formats (Iceberg) on object storage with ACID, schema evolution, time travel.\n",
+    "\n",
+    "**Stack:** DuckDB + PyIceberg (local Iceberg tables with SQLite catalog)\n",
+    "\n",
+    "**Maple Trust Bank** — synthetic BFSI data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Configuration — Plan A / Plan B\n",
+    "\n",
+    "Toggle the `USE_PLAN_A` flag below to switch between:\n",
+    "- **Plan A:** watsonx.data + Iceberg (IBM Cloud)\n",
+    "- **Plan B:** Local PyIceberg + DuckDB with SQLite catalog"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ── Configuration ──────────────────────────────────────────────────────\n",
+    "USE_PLAN_A = False  # Set True for watsonx.data + Iceberg; False for local PyIceberg + DuckDB\n",
+    "\n",
+    "# Data paths\n",
+    "DATA_DIR = \"../data\"\n",
+    "LINEAGE_PATH = f\"{DATA_DIR}/lineage/lineage_graph.json\"\n",
+    "\n",
+    "# Local Iceberg catalog config (Plan B)\n",
+    "WAREHOUSE_DIR = \"/tmp/iceberg_warehouse\"\n",
+    "CATALOG_DB = \"/tmp/iceberg_catalog.db\"\n",
+    "\n",
+    "if USE_PLAN_A:\n",
+    "    print(\"Plan A: watsonx.data + Iceberg — configure watsonx.data credentials.\")\n",
+    "else:\n",
+    "    print(\"Plan B: Local PyIceberg + DuckDB with SQLite catalog.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import duckdb\n",
+    "import pandas as pd\n",
+    "import json\n",
+    "import os\n",
+    "import time\n",
+    "import shutil\n",
+    "import pyarrow as pa\n",
+    "import pyarrow.parquet as pq\n",
+    "\n",
+    "pd.set_option(\"display.max_columns\", 20)\n",
+    "pd.set_option(\"display.width\", 120)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Section 1: The Pattern in One Paragraph\n",
+    "\n",
+    "The **lakehouse** is what happens when you give a data lake ACID transactions, schema enforcement, and time travel. Open table formats — Apache Iceberg, Delta Lake, Apache Hudi — made this possible by adding a metadata layer on top of object storage files. The key insight: the lakehouse is not a product, it's a *contract* between storage and compute. Any engine that understands Iceberg metadata can read and write the same tables with transactional guarantees. You get the cost and openness of the lake with the reliability of the warehouse. The tradeoff: more operational complexity than a warehouse, and the format wars (Iceberg vs. Delta vs. Hudi) have only recently settled in Iceberg's favor."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Section 2: When You'd Use It, When You Wouldn't\n",
+    "\n",
+    "| Use when | Don't use when |\n",
+    "|----------|----------------|\n",
+    "| Unified analytics + ML on open formats | Sub-second OLTP point lookups (use a database) |\n",
+    "| Schema evolution is required (fields added/renamed) | Simple BI on stable schemas (a warehouse is simpler) |\n",
+    "| Time travel / audit trail for regulatory compliance | Your data fits in a single Postgres instance |\n",
+    "| Mixed workloads: BI + data science + streaming | You have no one to operate the format metadata |\n",
+    "| Multi-engine access (Spark, Presto, DuckDB, Flink) | All your data is already in a well-governed warehouse |\n",
+    "| Cost-effective storage with compute elasticity | Your org equates 'lakehouse' with 'no governance needed' |"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Section 3: The Setup — Create Local Iceberg Tables"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Clean up any previous run\n",
+    "for path in [WAREHOUSE_DIR, CATALOG_DB]:\n",
+    "    if os.path.exists(path):\n",
+    "        if os.path.isdir(path):\n",
+    "            shutil.rmtree(path)\n",
+    "        else:\n",
+    "            os.remove(path)\n",
+    "\n",
+    "os.makedirs(WAREHOUSE_DIR, exist_ok=True)\n",
+    "print(f\"Iceberg warehouse: {WAREHOUSE_DIR}\")\n",
+    "print(f\"SQLite catalog:    {CATALOG_DB}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create PyIceberg catalog backed by SQLite\n",
+    "from pyiceberg.catalog.sql import SqlCatalog\n",
+    "\n",
+    "catalog = SqlCatalog(\n",
+    "    \"maple_trust\",\n",
+    "    **{\n",
+    "        \"uri\": f\"sqlite:///{CATALOG_DB}\",\n",
+    "        \"warehouse\": f\"file://{WAREHOUSE_DIR}\",\n",
+    "    },\n",
+    ")\n",
+    "\n",
+    "# Create a namespace for our bank\n",
+    "catalog.create_namespace(\"bfsi\")\n",
+    "print(\"Created Iceberg catalog 'maple_trust' with namespace 'bfsi'\")\n",
+    "print(f\"Namespaces: {catalog.list_namespaces()}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load raw data from parquet\n",
+    "branches_df = pd.read_parquet(f\"{DATA_DIR}/branches.parquet\")\n",
+    "customers_df = pd.read_parquet(f\"{DATA_DIR}/customers.parquet\")\n",
+    "accounts_df = pd.read_parquet(f\"{DATA_DIR}/accounts.parquet\")\n",
+    "transactions_df = pd.read_parquet(f\"{DATA_DIR}/transactions.parquet\")\n",
+    "\n",
+    "print(f\"Loaded: branches={len(branches_df)}, customers={len(customers_df)}, \"\n",
+    "      f\"accounts={len(accounts_df)}, transactions={len(transactions_df)}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Convert DataFrames to PyArrow tables for Iceberg ingestion\n",
+    "branches_arrow = pa.Table.from_pandas(branches_df)\n",
+    "customers_arrow = pa.Table.from_pandas(customers_df)\n",
+    "accounts_arrow = pa.Table.from_pandas(accounts_df)\n",
+    "transactions_arrow = pa.Table.from_pandas(transactions_df)\n",
+    "\n",
+    "print(\"Converted to Arrow tables for Iceberg ingestion\")\n",
+    "print(f\"  branches schema:     {branches_arrow.schema}\")\n",
+    "print(f\"  transactions schema: {transactions_arrow.schema}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create Iceberg tables and load data\n",
+    "print(\"📊 Reference Architecture Swimlane: Analytical Data Management & Storage\")\n",
+    "print(\"   Sub-zone: 'On Software Hub' — watsonx.data (Iceberg)\\n\")\n",
+    "\n",
+    "tables_config = [\n",
+    "    (\"bfsi.branches\", branches_arrow),\n",
+    "    (\"bfsi.customers\", customers_arrow),\n",
+    "    (\"bfsi.accounts\", accounts_arrow),\n",
+    "    (\"bfsi.transactions\", transactions_arrow),\n",
+    "]\n",
+    "\n",
+    "for table_name, arrow_table in tables_config:\n",
+    "    iceberg_table = catalog.create_table(table_name, schema=arrow_table.schema)\n",
+    "    iceberg_table.append(arrow_table)\n",
+    "    print(f\"  Created and loaded: {table_name} ({arrow_table.num_rows:,} rows)\")\n",
+    "\n",
+    "print(f\"\\nTables in catalog: {catalog.list_tables('bfsi')}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Inspect the Iceberg metadata structure\n",
+    "txn_table = catalog.load_table(\"bfsi.transactions\")\n",
+    "print(\"Iceberg metadata for bfsi.transactions:\")\n",
+    "print(f\"  Location:    {txn_table.location()}\")\n",
+    "print(f\"  Schema:      {txn_table.schema()}\")\n",
+    "print(f\"  Snapshots:   {len(txn_table.history())}\")\n",
+    "print(f\"  Current snapshot: {txn_table.current_snapshot()}\")\n",
+    "print()\n",
+    "print(\"This metadata is what makes the lakehouse different from a lake.\")\n",
+    "print(\"It provides: ACID, time travel, schema tracking, snapshot isolation.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Section 4: Three Canonical Queries"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Connect DuckDB and register Iceberg data\n",
+    "# Read Iceberg tables via PyIceberg into Arrow, then register in DuckDB\n",
+    "con = duckdb.connect()\n",
+    "\n",
+    "# Scan Iceberg tables to Arrow and register in DuckDB\n",
+    "for tbl_name in [\"branches\", \"customers\", \"accounts\", \"transactions\"]:\n",
+    "    iceberg_tbl = catalog.load_table(f\"bfsi.{tbl_name}\")\n",
+    "    arrow_data = iceberg_tbl.scan().to_arrow()\n",
+    "    con.register(tbl_name, arrow_data)\n",
+    "\n",
+    "print(\"Registered Iceberg tables in DuckDB:\")\n",
+    "print(con.execute(\"SHOW TABLES\").fetchdf())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Q1: Total transaction volume by branch for Q3 2024\n",
+    "\n",
+    "Query Iceberg tables via DuckDB — works like a warehouse, but on open formats."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "q1 = con.execute(\"\"\"\n",
+    "    SELECT\n",
+    "        t.branch_id,\n",
+    "        b.name AS branch_name,\n",
+    "        b.region,\n",
+    "        COUNT(*)           AS txn_count,\n",
+    "        SUM(t.amount)      AS total_amount,\n",
+    "        AVG(t.amount)      AS avg_amount\n",
+    "    FROM transactions t\n",
+    "    JOIN branches b ON t.branch_id = b.branch_id\n",
+    "    WHERE t.timestamp >= '2024-07-01' AND t.timestamp < '2024-10-01'\n",
+    "    GROUP BY t.branch_id, b.name, b.region\n",
+    "    ORDER BY total_amount DESC\n",
+    "\"\"\").fetchdf()\n",
+    "\n",
+    "print(\"Q1: Transaction volume by branch — Q3 2024 (top 10)\")\n",
+    "print(\"Same query as the lake, same results — but now with ACID guarantees.\")\n",
+    "q1.head(10)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Q2: Find all customers whose policy documents reference AML procedure X\n",
+    "\n",
+    "The lakehouse still can't search unstructured documents natively — but it *can* store embeddings alongside structured data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"Q2: Policy document search — AML procedure references\")\n",
+    "print(\"=\"*60)\n",
+    "print()\n",
+    "print(\"RESULT: Cannot be answered natively by the lakehouse.\")\n",
+    "print()\n",
+    "print(\"However, the lakehouse has an advantage over the lake:\")\n",
+    "print(\"  → It can store vector embeddings as a column alongside structured data\")\n",
+    "print(\"  → An embedding table in Iceberg could hold doc chunks + vectors\")\n",
+    "print(\"  → A vector-capable engine (watsonx.data + Milvus) could query it\")\n",
+    "print()\n",
+    "print(\"This is the bridge to Notebook 6 (RAG):\")\n",
+    "print(\"  Lakehouse stores the embeddings. RAG pipeline queries them.\")\n",
+    "print(\"  The lakehouse becomes the persistence layer for AI workloads.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Q3: Trace the lineage of branch_summary_quarterly back to source\n",
+    "\n",
+    "Iceberg metadata provides table-level lineage — snapshots, manifests, history. Better than the lake, but still not full pipeline lineage."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Part A: Iceberg snapshot history — table-level lineage\n",
+    "txn_table = catalog.load_table(\"bfsi.transactions\")\n",
+    "\n",
+    "print(\"Q3: Lineage — Iceberg snapshot history for bfsi.transactions\")\n",
+    "print(\"=\"*60)\n",
+    "print()\n",
+    "for snapshot in txn_table.history():\n",
+    "    print(f\"  Snapshot ID:  {snapshot.snapshot_id}\")\n",
+    "    print(f\"  Timestamp:    {snapshot.timestamp_ms}\")\n",
+    "    print()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Part B: External lineage graph — pipeline-level lineage\n",
+    "with open(LINEAGE_PATH) as f:\n",
+    "    lineage = json.load(f)\n",
+    "\n",
+    "target = \"consumed.branch_summary_quarterly\"\n",
+    "\n",
+    "def trace_lineage(target_node, edges, depth=0):\n",
+    "    upstream = [e for e in edges if e[\"to\"] == target_node]\n",
+    "    for edge in upstream:\n",
+    "        indent = \"  \" * depth\n",
+    "        print(f\"{indent}← {edge['from']}\")\n",
+    "        print(f\"{indent}   transform: {edge['transform'][:60]}...\")\n",
+    "        trace_lineage(edge[\"from\"], edges, depth + 1)\n",
+    "\n",
+    "print(f\"\\nExternal lineage graph for: {target}\")\n",
+    "trace_lineage(target, lineage[\"edges\"])\n",
+    "print()\n",
+    "print(\"✅ Iceberg gives us TABLE-level lineage (snapshots, who wrote what, when).\")\n",
+    "print(\"⚠️  PIPELINE-level lineage (which job transformed what) still needs an external graph.\")\n",
+    "print(\"   → IBM Knowledge Catalog + DataStage provide this in the IBM stack.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Section 5: Where This Pattern Breaks — Lakehouse Features and Limits"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Feature: Schema Evolution\n",
+    "\n",
+    "Add a column, query old and new data seamlessly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Schema evolution: add a 'risk_flag' column to branches\n",
+    "from pyiceberg.types import BooleanType\n",
+    "\n",
+    "branches_table = catalog.load_table(\"bfsi.branches\")\n",
+    "print(\"Before schema evolution:\")\n",
+    "print(f\"  Columns: {[f.name for f in branches_table.schema().fields]}\")\n",
+    "\n",
+    "# Add a new column\n",
+    "with branches_table.update_schema() as update:\n",
+    "    update.add_column(\"risk_flag\", BooleanType())\n",
+    "\n",
+    "# Reload to see the change\n",
+    "branches_table = catalog.load_table(\"bfsi.branches\")\n",
+    "print(\"\\nAfter schema evolution:\")\n",
+    "print(f\"  Columns: {[f.name for f in branches_table.schema().fields]}\")\n",
+    "print()\n",
+    "print(\"Old data still reads correctly — the new column is NULL for existing rows.\")\n",
+    "print(\"This is seamless. No ALTER TABLE migration. No downtime.\")\n",
+    "\n",
+    "# Verify old data reads with new schema\n",
+    "evolved_data = branches_table.scan().to_arrow().to_pandas()\n",
+    "print(f\"\\nSample after evolution (risk_flag is null for old rows):\")\n",
+    "evolved_data[[\"branch_id\", \"name\", \"risk_flag\"]].head(5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Feature: Time Travel\n",
+    "\n",
+    "Query the table as of a previous snapshot."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Add more data to create a new snapshot\n",
+    "new_txns = pa.table({\n",
+    "    \"transaction_id\": [f\"TXN-NEW-{i:06d}\" for i in range(1000)],\n",
+    "    \"account_id\": [f\"ACCT-{(i % 200000) + 1:06d}\" for i in range(1000)],\n",
+    "    \"branch_id\": [f\"MTB-{(i % 50) + 1:03d}\" for i in range(1000)],\n",
+    "    \"amount\": [float(100 + i) for i in range(1000)],\n",
+    "    \"currency\": [\"CAD\"] * 1000,\n",
+    "    \"timestamp\": pd.to_datetime([\"2024-12-01\"] * 1000),\n",
+    "    \"transaction_type\": [\"deposit\"] * 1000,\n",
+    "    \"channel\": [\"online\"] * 1000,\n",
+    "    \"counterparty_id\": [None] * 1000,\n",
+    "})\n",
+    "\n",
+    "txn_table = catalog.load_table(\"bfsi.transactions\")\n",
+    "txn_table.append(new_txns)\n",
+    "print(\"Added 1,000 new transactions (snapshot 2 created)\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Time travel: compare snapshots\n",
+    "txn_table = catalog.load_table(\"bfsi.transactions\")\n",
+    "history = txn_table.history()\n",
+    "\n",
+    "print(\"Transaction table snapshot history:\")\n",
+    "for i, snapshot in enumerate(history):\n",
+    "    print(f\"  Snapshot {i}: ID={snapshot.snapshot_id}, ts={snapshot.timestamp_ms}\")\n",
+    "\n",
+    "# Current count\n",
+    "current_count = txn_table.scan().to_arrow().num_rows\n",
+    "print(f\"\\nCurrent snapshot: {current_count:,} rows\")\n",
+    "\n",
+    "# Previous snapshot (time travel)\n",
+    "if len(history) > 1:\n",
+    "    old_snapshot_id = history[0].snapshot_id\n",
+    "    old_count = txn_table.scan(snapshot_id=old_snapshot_id).to_arrow().num_rows\n",
+    "    print(f\"Previous snapshot (ID={old_snapshot_id}): {old_count:,} rows\")\n",
+    "    print(f\"\\nDifference: {current_count - old_count:,} rows added\")\n",
+    "    print()\n",
+    "    print(\"Time travel enables: audit trails, rollback, reproducible analytics.\")\n",
+    "    print(\"Regulators love this — 'show me the data as it was on December 31st.'\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Feature: Partition Pruning\n",
+    "\n",
+    "Iceberg tracks min/max statistics per file, enabling efficient scan pruning."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Show the manifest files that Iceberg uses for pruning\n",
+    "txn_table = catalog.load_table(\"bfsi.transactions\")\n",
+    "current_snap = txn_table.current_snapshot()\n",
+    "\n",
+    "print(\"Iceberg manifest information:\")\n",
+    "if current_snap and current_snap.manifests(txn_table.io):\n",
+    "    manifests = current_snap.manifests(txn_table.io)\n",
+    "    for i, m in enumerate(manifests[:5]):\n",
+    "        print(f\"  Manifest {i}: path={os.path.basename(m.manifest_path)}\")\n",
+    "        print(f\"    added_rows={m.added_rows_count}, existing_rows={m.existing_rows_count}\")\n",
+    "\n",
+    "print()\n",
+    "print(\"Iceberg uses manifest files with column-level min/max stats.\")\n",
+    "print(\"This enables partition pruning — skip entire files that don't match the filter.\")\n",
+    "print(\"Example: a query for Q3 2024 skips all files outside that date range.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Break: Sub-millisecond point lookups (OLTP)\n",
+    "\n",
+    "The lakehouse is optimized for analytical scans, not single-row seeks."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Simulate OLTP-style point lookup: find one specific transaction\n",
+    "target_txn_id = \"TXN-NEW-000001\"\n",
+    "\n",
+    "# Lakehouse scan\n",
+    "start = time.time()\n",
+    "result = txn_table.scan(\n",
+    "    row_filter=f\"transaction_id == '{target_txn_id}'\"\n",
+    ").to_arrow()\n",
+    "lakehouse_ms = (time.time() - start) * 1000\n",
+    "\n",
+    "print(f\"Point lookup for transaction_id = '{target_txn_id}'\")\n",
+    "print(f\"  Lakehouse (Iceberg scan): {lakehouse_ms:.1f} ms — found {result.num_rows} row(s)\")\n",
+    "print()\n",
+    "print(\"For comparison, a database index lookup would be < 1 ms.\")\n",
+    "print(f\"The lakehouse took {lakehouse_ms:.0f} ms because it scanned manifest files + data files.\")\n",
+    "print()\n",
+    "print(\"⚠️  The lakehouse is optimized for SCAN, not SEEK.\")\n",
+    "print(\"   For OLTP workloads (banking transactions, real-time lookups),\")\n",
+    "print(\"   use a database (Postgres, Db2). The lakehouse is for analytics.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Section 6: The IBM Stack Mapping\n",
+    "\n",
+    "| Component | IBM Product | Swimlane |\n",
+    "|-----------|-------------|----------|\n",
+    "| Lakehouse Engine | watsonx.data (Presto, Spark) | Analytical Data Management & Storage |\n",
+    "| Table Format | Apache Iceberg (native in watsonx.data) | Analytical Data Management & Storage |\n",
+    "| Object Storage | IBM Cloud Object Storage (COS) | Analytical Data Management & Storage |\n",
+    "| Catalog | Iceberg catalog (Hive Metastore or Nessie) | Discovery & Exploration |\n",
+    "| Governance | IBM Knowledge Catalog | Information & Model Management & Governance |\n",
+    "\n",
+    "**Swimlane:** The lakehouse sits in the \"On Software Hub\" box — **watsonx.data IS the lakehouse play for IBM.**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"📊 Reference Architecture Swimlane: Analytical Data Management & Storage\")\n",
+    "print(\"   Sub-zone: 'On Software Hub' — watsonx.data\")\n",
+    "print()\n",
+    "print(\"IBM Product Mapping:\")\n",
+    "print(\"  Lakehouse Engine  → watsonx.data (Presto / Spark)\")\n",
+    "print(\"  Table Format      → Apache Iceberg (native support)\")\n",
+    "print(\"  Object Storage    → IBM Cloud Object Storage (COS)\")\n",
+    "print(\"  Catalog           → Iceberg catalog (Hive Metastore or Nessie)\")\n",
+    "print(\"  Governance        → IBM Knowledge Catalog\")\n",
+    "print()\n",
+    "print(\"watsonx.data IS the lakehouse play for IBM.\")\n",
+    "print(\"It bundles Presto + Spark + Iceberg + Milvus into one managed service.\")\n",
+    "print(\"Multi-engine, open format, governed.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Section 7: BFSI Reality Check\n",
+    "\n",
+    "Canadian banks are actively migrating from legacy warehouses (Teradata, Netezza, on-prem Db2) to lakehouse architectures, often on watsonx.data or Databricks. The primary driver is not cost — it's AI. ML and AI workloads need access to the same data that BI dashboards consume, but in open formats that Python and Spark can read natively. Maintaining two copies — one in the warehouse for BI, one in the lake for ML — is expensive, error-prone, and creates governance nightmares (which copy is the source of truth?). The lakehouse eliminates the duplicate by putting everything in Iceberg tables that both Presto (for SQL/BI) and Spark (for ML) can access. The banks that are succeeding started small — one domain, one use case — and proved the model before expanding. The ones that are struggling tried to migrate everything at once. The lakehouse is where the warehouse and the lake finally stop arguing."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Clean up\n",
+    "con.close()\n",
+    "print(\"Notebook 3 complete.\")\n",
+    "print()\n",
+    "print(\"Key takeaway: The lakehouse adds ACID, schema evolution, and time travel\")\n",
+    "print(\"to the data lake — giving you warehouse reliability with lake flexibility.\")\n",
+    "print(\"Next: Notebook 4 (Virtualization) — what if you can't move the data at all?\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/notebooks/04-virtualization.ipynb
+++ b/notebooks/04-virtualization.ipynb
@@ -1,0 +1,519 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Notebook 4: Data Virtualization\n",
+    "\n",
+    "**Pattern:** Federated queries across heterogeneous sources without ETL. Leave data where it lives.\n",
+    "\n",
+    "**Stack:** DuckDB multi-source federation (portable proxy for Trino / watsonx.data federation). Query Postgres AND Parquet files without moving data.\n",
+    "\n",
+    "**Maple Trust Bank** — synthetic BFSI data\n",
+    "\n",
+    "🎯 **Cameo cell** — run Q1 during Block 1 for a quick federation demo (3 min)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Configuration — Plan A / Plan B\n",
+    "\n",
+    "Toggle the `USE_PLAN_A` flag below to switch between:\n",
+    "- **Plan A:** Trino or watsonx.data federation\n",
+    "- **Plan B:** DuckDB with `postgres_scanner` extension (local Docker)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ── Configuration ──────────────────────────────────────────────────────\n",
+    "USE_PLAN_A = False  # Set True for Trino/watsonx.data; False for DuckDB + postgres_scanner\n",
+    "\n",
+    "# Postgres connection (Docker)\n",
+    "PG_HOST = \"localhost\"\n",
+    "PG_PORT = 5432\n",
+    "PG_USER = \"lecture\"\n",
+    "PG_PASSWORD = \"lecture\"\n",
+    "PG_DATABASE = \"bfsi\"\n",
+    "\n",
+    "# Data paths (for parquet files — Source B)\n",
+    "DATA_DIR = \"../data\"\n",
+    "LINEAGE_PATH = f\"{DATA_DIR}/lineage/lineage_graph.json\"\n",
+    "\n",
+    "if USE_PLAN_A:\n",
+    "    print(\"Plan A: Trino / watsonx.data federation — configure Trino endpoints.\")\n",
+    "else:\n",
+    "    print(\"Plan B: DuckDB + postgres_scanner — ensure 'docker compose up postgres' is running.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import duckdb\n",
+    "import pandas as pd\n",
+    "import json\n",
+    "import os\n",
+    "import time\n",
+    "from sqlalchemy import create_engine, text\n",
+    "\n",
+    "pd.set_option(\"display.max_columns\", 20)\n",
+    "pd.set_option(\"display.width\", 120)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Section 1: The Pattern in One Paragraph\n",
+    "\n",
+    "**Data virtualization** is the \"don't move it, query it\" pattern. Instead of extracting, transforming, and loading data into a central warehouse, you federate queries across databases, files, and APIs in place — without copying. It sounds elegant, and it is — for the right use cases. The most misunderstood pattern in data architecture, virtualization is not faster (it adds network hops), not cheaper (federation engines are complex), and not simpler (query planning across heterogeneous sources is hard). What it IS about: data that *cannot* move. Data sovereignty laws, contractual obligations, latency requirements, or system-of-record ownership rules that prohibit copying. When someone tells you \"we'll just virtualize everything,\" ask them about their SLAs."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Section 2: When You'd Use It, When You Wouldn't\n",
+    "\n",
+    "| Use when | Don't use when |\n",
+    "|----------|----------------|\n",
+    "| Data cannot move (sovereignty, contracts, regulation) | High-volume analytical scans (performance degrades) |\n",
+    "| Federated queries across heterogeneous sources | Latency-sensitive workloads (< 100ms) |\n",
+    "| Real-time access to operational systems (read-only) | Data is all in one place already |\n",
+    "| Reducing data copies to avoid governance sprawl | You need repeatable, deterministic analytics |\n",
+    "| Cross-LOB queries where each LOB owns its data | Your data sources have unreliable uptime |\n",
+    "| Quick proof-of-concept without building pipelines | Production dashboards with strict SLAs |"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Section 3: The Setup — Two Separate Data Sources\n",
+    "\n",
+    "- **Source A:** Postgres (Docker) — branches and customers\n",
+    "- **Source B:** Raw parquet files — transactions and accounts\n",
+    "\n",
+    "Data stays where it lives. We federate across both with DuckDB."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Source A: Load branches and customers into Postgres\n",
+    "print(\"📊 Reference Architecture Swimlane: Data Sources\")\n",
+    "print(\"   Loading reference data into Postgres (simulating an operational system)\\n\")\n",
+    "\n",
+    "pg_url = f\"postgresql://{PG_USER}:{PG_PASSWORD}@{PG_HOST}:{PG_PORT}/{PG_DATABASE}\"\n",
+    "engine = create_engine(pg_url)\n",
+    "\n",
+    "branches_df = pd.read_parquet(f\"{DATA_DIR}/branches.parquet\")\n",
+    "customers_df = pd.read_parquet(f\"{DATA_DIR}/customers.parquet\")\n",
+    "\n",
+    "branches_df.to_sql(\"branches\", engine, if_exists=\"replace\", index=False)\n",
+    "customers_df.to_sql(\"customers\", engine, if_exists=\"replace\", index=False)\n",
+    "\n",
+    "# Verify\n",
+    "with engine.connect() as conn:\n",
+    "    b_count = conn.execute(text(\"SELECT COUNT(*) FROM branches\")).scalar()\n",
+    "    c_count = conn.execute(text(\"SELECT COUNT(*) FROM customers\")).scalar()\n",
+    "\n",
+    "print(f\"  Source A (Postgres): branches={b_count}, customers={c_count}\")\n",
+    "print(f\"  Source B (Parquet):  transactions, accounts (on disk)\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set up DuckDB with postgres_scanner for federation\n",
+    "con = duckdb.connect()\n",
+    "\n",
+    "# Install and load postgres_scanner extension\n",
+    "con.execute(\"INSTALL postgres;\")\n",
+    "con.execute(\"LOAD postgres;\")\n",
+    "\n",
+    "# Attach Postgres as a federated source\n",
+    "con.execute(f\"\"\"\n",
+    "    ATTACH 'dbname={PG_DATABASE} user={PG_USER} password={PG_PASSWORD} host={PG_HOST} port={PG_PORT}'\n",
+    "    AS pg_source (TYPE POSTGRES, READ_ONLY);\n",
+    "\"\"\")\n",
+    "\n",
+    "print(\"DuckDB connected with postgres_scanner.\")\n",
+    "print(\"  Source A: pg_source.public.branches, pg_source.public.customers (Postgres)\")\n",
+    "print(f\"  Source B: {DATA_DIR}/transactions.parquet, {DATA_DIR}/accounts.parquet (files)\")\n",
+    "print()\n",
+    "print(\"Data has NOT been moved. Queries will federate across both sources.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Verify both sources are accessible\n",
+    "pg_tables = con.execute(\"SELECT table_name FROM information_schema.tables WHERE table_schema = 'pg_source.public' OR table_catalog = 'pg_source'\").fetchdf()\n",
+    "print(\"Postgres tables accessible via federation:\")\n",
+    "pg_branches = con.execute(\"SELECT COUNT(*) as cnt FROM pg_source.public.branches\").fetchone()[0]\n",
+    "pg_customers = con.execute(\"SELECT COUNT(*) as cnt FROM pg_source.public.customers\").fetchone()[0]\n",
+    "print(f\"  pg_source.public.branches:  {pg_branches} rows\")\n",
+    "print(f\"  pg_source.public.customers: {pg_customers:,} rows\")\n",
+    "\n",
+    "parquet_txn = con.execute(f\"SELECT COUNT(*) FROM '{DATA_DIR}/transactions.parquet'\").fetchone()[0]\n",
+    "parquet_acct = con.execute(f\"SELECT COUNT(*) FROM '{DATA_DIR}/accounts.parquet'\").fetchone()[0]\n",
+    "print(f\"\\nParquet files on disk:\")\n",
+    "print(f\"  transactions.parquet: {parquet_txn:,} rows\")\n",
+    "print(f\"  accounts.parquet:     {parquet_acct:,} rows\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Section 4: Three Canonical Queries"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Q1: Total transaction volume by branch for Q3 2024 (FEDERATED)\n",
+    "\n",
+    "🎯 **Cameo cell** — run this during Block 1 for a quick federation demo.\n",
+    "\n",
+    "This query joins Postgres (branches) with parquet files (transactions) — data never moved."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# FEDERATED QUERY: Postgres branches + Parquet transactions\n",
+    "start = time.time()\n",
+    "\n",
+    "q1 = con.execute(f\"\"\"\n",
+    "    SELECT\n",
+    "        t.branch_id,\n",
+    "        b.name AS branch_name,\n",
+    "        b.region,\n",
+    "        COUNT(*)           AS txn_count,\n",
+    "        SUM(t.amount)      AS total_amount,\n",
+    "        AVG(t.amount)      AS avg_amount\n",
+    "    FROM '{DATA_DIR}/transactions.parquet' t\n",
+    "    JOIN pg_source.public.branches b ON t.branch_id = b.branch_id\n",
+    "    WHERE t.timestamp >= '2024-07-01' AND t.timestamp < '2024-10-01'\n",
+    "    GROUP BY t.branch_id, b.name, b.region\n",
+    "    ORDER BY total_amount DESC\n",
+    "\"\"\").fetchdf()\n",
+    "\n",
+    "federated_ms = (time.time() - start) * 1000\n",
+    "\n",
+    "print(\"📊 Reference Architecture Swimlane: Data Access\")\n",
+    "print(\"   (Data Virtualization = federated query across sources)\\n\")\n",
+    "print(f\"Q1: Transaction volume by branch — Q3 2024 (FEDERATED, {federated_ms:.0f} ms)\")\n",
+    "print(f\"  Source A: pg_source.public.branches (Postgres)\")\n",
+    "print(f\"  Source B: transactions.parquet (local file)\")\n",
+    "print(f\"  Data moved: ZERO bytes. Query crossed system boundaries.\\n\")\n",
+    "q1.head(10)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Q2: Find all customers whose policy documents reference AML procedure X\n",
+    "\n",
+    "Virtualization cannot federate over unstructured content."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"Q2: Policy document search — AML procedure references\")\n",
+    "print(\"=\"*60)\n",
+    "print()\n",
+    "print(\"RESULT: Cannot be answered via federation.\")\n",
+    "print()\n",
+    "print(\"Virtualization federates structured queries across databases and files.\")\n",
+    "print(\"It cannot:\")\n",
+    "print(\"  → Search inside PDF documents\")\n",
+    "print(\"  → Perform full-text search across document stores\")\n",
+    "print(\"  → Federate over unstructured content\")\n",
+    "print()\n",
+    "print(\"You could federate a query TO a search engine (e.g., Elasticsearch),\")\n",
+    "print(\"but the virtualization layer doesn't understand document semantics.\")\n",
+    "print()\n",
+    "print(\"→ Addressed in Notebook 6 (RAG) with vector search.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Q3: Trace the lineage of branch_summary_quarterly back to source\n",
+    "\n",
+    "Virtualization makes lineage HARDER — there's no materialized layer to instrument."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"Q3: Lineage in a virtualized environment\")\n",
+    "print(\"=\"*60)\n",
+    "print()\n",
+    "print(\"The fundamental lineage challenge with virtualization:\")\n",
+    "print()\n",
+    "print(\"  In a warehouse/lakehouse: data is materialized → you can track what went in.\")\n",
+    "print(\"  In virtualization: data is NOT materialized → lineage is the QUERY PLAN.\")\n",
+    "print()\n",
+    "print(\"Consider our Q1 federated query:\")\n",
+    "print(\"  → Source A: Postgres branches table (owned by Branch Operations)\")\n",
+    "print(\"  → Source B: Parquet transactions file (owned by Data Engineering)\")\n",
+    "print(\"  → Result: branch_summary — but WHERE does this result live? Nowhere.\")\n",
+    "print()\n",
+    "print(\"The lineage graph for virtualized queries is:\")\n",
+    "print(\"  1. Ephemeral — it only exists during query execution\")\n",
+    "print(\"  2. Cross-system — it spans multiple ownership boundaries\")\n",
+    "print(\"  3. Non-deterministic — source data may change between executions\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Show the query plan to illustrate cross-source lineage\n",
+    "plan = con.execute(f\"\"\"\n",
+    "    EXPLAIN\n",
+    "    SELECT t.branch_id, b.name, COUNT(*) AS txn_count\n",
+    "    FROM '{DATA_DIR}/transactions.parquet' t\n",
+    "    JOIN pg_source.public.branches b ON t.branch_id = b.branch_id\n",
+    "    WHERE t.timestamp >= '2024-07-01' AND t.timestamp < '2024-10-01'\n",
+    "    GROUP BY t.branch_id, b.name\n",
+    "\"\"\").fetchdf()\n",
+    "\n",
+    "print(\"Query plan (federation lineage):\")\n",
+    "for row in plan.itertuples():\n",
+    "    print(row[1])\n",
+    "print()\n",
+    "print(\"⚠️  This plan IS the lineage. There's no persistent record unless you log it.\")\n",
+    "print(\"   IBM Data Virtualization (CP4D) logs query plans for governance.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# For reference: the external lineage graph\n",
+    "with open(LINEAGE_PATH) as f:\n",
+    "    lineage = json.load(f)\n",
+    "\n",
+    "target = \"consumed.branch_summary_quarterly\"\n",
+    "\n",
+    "def trace_lineage(target_node, edges, depth=0):\n",
+    "    upstream = [e for e in edges if e[\"to\"] == target_node]\n",
+    "    for edge in upstream:\n",
+    "        indent = \"  \" * depth\n",
+    "        print(f\"{indent}← {edge['from']}\")\n",
+    "        trace_lineage(edge[\"from\"], edges, depth + 1)\n",
+    "\n",
+    "print(f\"External lineage graph for: {target}\")\n",
+    "trace_lineage(target, lineage[\"edges\"])\n",
+    "print()\n",
+    "print(\"In a virtualized world, each arrow in this graph is a live federation link.\")\n",
+    "print(\"If any source goes down, the query fails. No cached fallback.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Section 5: Where This Pattern Breaks — Performance"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Performance comparison: federated vs. local\n",
+    "print(\"Performance break: Federated vs. Local query on full 1M transactions\\n\")\n",
+    "\n",
+    "# Federated: join across Postgres + Parquet\n",
+    "start = time.time()\n",
+    "federated_result = con.execute(f\"\"\"\n",
+    "    SELECT\n",
+    "        b.region,\n",
+    "        COUNT(*)           AS txn_count,\n",
+    "        SUM(t.amount)      AS total_amount\n",
+    "    FROM '{DATA_DIR}/transactions.parquet' t\n",
+    "    JOIN pg_source.public.branches b ON t.branch_id = b.branch_id\n",
+    "    GROUP BY b.region\n",
+    "    ORDER BY total_amount DESC\n",
+    "\"\"\").fetchdf()\n",
+    "federated_time = (time.time() - start) * 1000\n",
+    "\n",
+    "print(f\"  Federated (Postgres + Parquet): {federated_time:.0f} ms\")\n",
+    "print(federated_result.to_string(index=False))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Local: same query on local parquet files only (no federation)\n",
+    "start = time.time()\n",
+    "local_result = con.execute(f\"\"\"\n",
+    "    SELECT\n",
+    "        b.region,\n",
+    "        COUNT(*)           AS txn_count,\n",
+    "        SUM(t.amount)      AS total_amount\n",
+    "    FROM '{DATA_DIR}/transactions.parquet' t\n",
+    "    JOIN '{DATA_DIR}/branches.parquet' b ON t.branch_id = b.branch_id\n",
+    "    GROUP BY b.region\n",
+    "    ORDER BY total_amount DESC\n",
+    "\"\"\").fetchdf()\n",
+    "local_time = (time.time() - start) * 1000\n",
+    "\n",
+    "print(f\"  Local (all Parquet):            {local_time:.0f} ms\")\n",
+    "print(local_result.to_string(index=False))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Summary\n",
+    "slowdown = federated_time / local_time if local_time > 0 else float('inf')\n",
+    "\n",
+    "print(f\"\\nPerformance comparison:\")\n",
+    "print(f\"  Federated: {federated_time:.0f} ms\")\n",
+    "print(f\"  Local:     {local_time:.0f} ms\")\n",
+    "print(f\"  Slowdown:  {slowdown:.1f}x\")\n",
+    "print()\n",
+    "print(\"The federation overhead comes from:\")\n",
+    "print(\"  1. Network round-trip to Postgres\")\n",
+    "print(\"  2. Cross-engine query planning\")\n",
+    "print(\"  3. Data serialization/deserialization across the boundary\")\n",
+    "print()\n",
+    "print('\"Virtualization is about ACCESS, not PERFORMANCE.\"')\n",
+    "print('\"When someone tells you virtualization replaces ETL, ask them about their SLAs.\"')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Section 6: The IBM Stack Mapping\n",
+    "\n",
+    "| Component | IBM Product | Swimlane |\n",
+    "|-----------|-------------|----------|\n",
+    "| Federation Engine | Data Virtualization (CP4D) | Data Access |\n",
+    "| Federation Engine | watsonx.data (Presto federation) | Data Access |\n",
+    "| Connectors | 100+ connectors (JDBC, ODBC, REST) | Ingestion & Integration |\n",
+    "| Partner | Denodo (strategic partner) | Data Access |\n",
+    "| Governance | IBM Knowledge Catalog (query logging) | Information & Model Management & Governance |\n",
+    "\n",
+    "**Swimlane:** Data Access — the middle-right section of the reference architecture diagram.\n",
+    "\n",
+    "**Note:** \"Data Virtualization is IBM's answer to 'we have 47 data sources and the CISO won't let us copy anything.'\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"📊 Reference Architecture Swimlane: Data Access\")\n",
+    "print(\"   (middle-right section of the reference architecture)\\n\")\n",
+    "print(\"IBM Product Mapping:\")\n",
+    "print(\"  Federation Engine → Data Virtualization service (CP4D)\")\n",
+    "print(\"  Federation Engine → watsonx.data (Presto federation)\")\n",
+    "print(\"  Connectors        → 100+ connectors (JDBC, ODBC, REST, S3, etc.)\")\n",
+    "print(\"  Partner           → Denodo (strategic partner for complex federation)\")\n",
+    "print(\"  Governance        → IBM Knowledge Catalog (query plan logging)\")\n",
+    "print()\n",
+    "print(\"Data Virtualization is IBM's answer to:\")\n",
+    "print(\"'We have 47 data sources and the CISO won't let us copy anything.'\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Section 7: BFSI Reality Check\n",
+    "\n",
+    "Canadian banks use virtualization heavily for cross-line-of-business queries where data sovereignty prevents consolidation. A retail banking analyst needs commercial banking exposure data for a relationship view, but the commercial data sits in a different system of record under a different data steward. OSFI (the regulator) requires certain data to remain in specific systems of record — the account master must stay in the core banking system, the KYC records must stay in the compliance platform. Virtualization doesn't replace these systems; it provides a read-only query layer across them. The banks that use it successfully treat it as what it is: a compliance access tool, not an analytics engine. The ones that fail try to build dashboards on federated queries and discover that join performance across system boundaries is unpredictable. Virtualization isn't an architecture choice — it's a regulatory compliance tool."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Clean up\n",
+    "con.close()\n",
+    "engine.dispose()\n",
+    "print(\"Notebook 4 complete.\")\n",
+    "print()\n",
+    "print(\"Key takeaway: Virtualization is about access, not performance.\")\n",
+    "print(\"Use it when data CANNOT move. Not when you CHOOSE not to move it.\")\n",
+    "print(\"Next: Notebook 5 (Data Mesh) — what if the problem isn't technology at all?\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/notebooks/05-data-mesh.ipynb
+++ b/notebooks/05-data-mesh.ipynb
@@ -1,0 +1,776 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Notebook 5: Data Mesh\n",
+    "\n",
+    "**Pattern:** Organizational pattern — domain teams own their data as products. Decentralized ownership, federated governance.\n",
+    "\n",
+    "**Stack:** DuckDB + simulated per-domain catalogs with data product contracts (JSON schemas)\n",
+    "\n",
+    "**Maple Trust Bank** — synthetic BFSI data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Configuration"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ── Configuration ──────────────────────────────────────────────────────\n",
+    "DATA_DIR = \"../data\"\n",
+    "LINEAGE_PATH = f\"{DATA_DIR}/lineage/lineage_graph.json\"\n",
+    "MESH_DIR = \"/tmp/data_mesh_demo\"\n",
+    "\n",
+    "print(\"Data Mesh simulation — three banking domains with data product contracts.\")\n",
+    "print(f\"Mesh workspace: {MESH_DIR}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import duckdb\n",
+    "import pandas as pd\n",
+    "import json\n",
+    "import os\n",
+    "import shutil\n",
+    "import pyarrow as pa\n",
+    "import pyarrow.parquet as pq\n",
+    "\n",
+    "pd.set_option(\"display.max_columns\", 20)\n",
+    "pd.set_option(\"display.width\", 120)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Section 1: The Pattern in One Paragraph\n",
+    "\n",
+    "**Data mesh** is not a technology — it's an organizational pattern. Four principles, coined by Zhamak Dehghani: (1) domain ownership — the team that creates data owns it, (2) data as a product — domains publish curated, documented, SLA-backed data products, (3) self-serve data platform — infrastructure that makes it easy for domains to publish, (4) federated computational governance — global standards enforced locally. The idea is powerful: stop pretending a central team can understand and govern all data. Let the people who know the data best own it. The problem: this requires product thinking, organizational maturity, and investment that most companies don't have. Data mesh is the most over-hyped and under-implemented pattern in the industry. It's the right answer for organizations with 500+ data engineers and strong product culture. For everyone else, it's a conference talk."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Section 2: When You'd Use It, When You Wouldn't\n",
+    "\n",
+    "| Use when | Don't use when |\n",
+    "|----------|----------------|\n",
+    "| Large org with strong, autonomous domain teams | Small team (< 50 data people) |\n",
+    "| Clear domain boundaries aligned to business units | No domain ownership culture |\n",
+    "| Product thinking maturity (PMs for data) | Orgs without product thinking discipline |\n",
+    "| Central platform team can build self-serve infra | \"We just want to query everything from one place\" |\n",
+    "| Each domain has enough engineers to own a pipeline | Data engineering is fully centralized |\n",
+    "| Governance is mature enough to federate | Governance barely exists centrally |"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Section 3: The Setup — Simulated Data Mesh\n",
+    "\n",
+    "We simulate a mesh with three banking domains:\n",
+    "- **Retail Banking** — owns customers, retail accounts, retail transactions\n",
+    "- **Commercial Banking** — owns commercial accounts, commercial transactions\n",
+    "- **Risk & Compliance** — owns AML alerts, risk scores, entity links\n",
+    "\n",
+    "Each domain publishes a **data product** with a JSON schema contract.\n",
+    "\n",
+    "> ⚠️ **This is a simulation.** Real data mesh requires organizational change, domain team autonomy, self-serve infrastructure, and federated governance. A notebook can show the consumer experience; it cannot show the org design."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Clean up previous runs\n",
+    "if os.path.exists(MESH_DIR):\n",
+    "    shutil.rmtree(MESH_DIR)\n",
+    "\n",
+    "# Create domain directories (each domain owns its own namespace)\n",
+    "domains = [\"retail_banking\", \"commercial_banking\", \"risk_compliance\"]\n",
+    "for domain in domains:\n",
+    "    os.makedirs(os.path.join(MESH_DIR, domain), exist_ok=True)\n",
+    "\n",
+    "print(\"Created domain directories:\")\n",
+    "for d in domains:\n",
+    "    print(f\"  {MESH_DIR}/{d}/\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load raw data\n",
+    "branches_df = pd.read_parquet(f\"{DATA_DIR}/branches.parquet\")\n",
+    "customers_df = pd.read_parquet(f\"{DATA_DIR}/customers.parquet\")\n",
+    "accounts_df = pd.read_parquet(f\"{DATA_DIR}/accounts.parquet\")\n",
+    "transactions_df = pd.read_parquet(f\"{DATA_DIR}/transactions.parquet\")\n",
+    "\n",
+    "print(f\"Loaded raw data: branches={len(branches_df)}, customers={len(customers_df)}, \"\n",
+    "      f\"accounts={len(accounts_df)}, transactions={len(transactions_df)}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define data product contracts (JSON schema)\n",
+    "contracts = {\n",
+    "    \"retail_banking\": {\n",
+    "        \"domain\": \"Retail Banking\",\n",
+    "        \"owner\": \"retail_data_team@mapletrust.ca\",\n",
+    "        \"sla\": \"99.5% availability, refreshed daily by 06:00 ET\",\n",
+    "        \"products\": {\n",
+    "            \"customers\": {\n",
+    "                \"description\": \"Retail customer master data\",\n",
+    "                \"schema\": {\n",
+    "                    \"required_fields\": [\"customer_id\", \"name\", \"segment\", \"kyc_status\", \"risk_score\"],\n",
+    "                    \"types\": {\"customer_id\": \"string\", \"name\": \"string\", \"segment\": \"string\",\n",
+    "                              \"kyc_status\": \"string\", \"risk_score\": \"integer\"},\n",
+    "                    \"constraints\": {\"segment\": [\"retail\", \"wealth\"], \"risk_score\": \"1-100\"}\n",
+    "                },\n",
+    "                \"row_count_range\": [50000, 150000],\n",
+    "                \"freshness\": \"daily\"\n",
+    "            },\n",
+    "            \"retail_accounts\": {\n",
+    "                \"description\": \"Retail banking accounts (chequing, savings)\",\n",
+    "                \"schema\": {\n",
+    "                    \"required_fields\": [\"account_id\", \"customer_id\", \"account_type\", \"status\", \"balance\"],\n",
+    "                    \"types\": {\"account_id\": \"string\", \"customer_id\": \"string\", \"account_type\": \"string\",\n",
+    "                              \"status\": \"string\", \"balance\": \"float\"},\n",
+    "                    \"constraints\": {\"account_type\": [\"chequing\", \"savings\", \"credit\"]}\n",
+    "                },\n",
+    "                \"freshness\": \"daily\"\n",
+    "            },\n",
+    "            \"retail_transactions\": {\n",
+    "                \"description\": \"Retail transaction events\",\n",
+    "                \"schema\": {\n",
+    "                    \"required_fields\": [\"transaction_id\", \"account_id\", \"branch_id\", \"amount\", \"timestamp\"],\n",
+    "                    \"types\": {\"transaction_id\": \"string\", \"account_id\": \"string\", \"branch_id\": \"string\",\n",
+    "                              \"amount\": \"float\", \"timestamp\": \"datetime\"}\n",
+    "                },\n",
+    "                \"freshness\": \"near-real-time\"\n",
+    "            }\n",
+    "        }\n",
+    "    },\n",
+    "    \"commercial_banking\": {\n",
+    "        \"domain\": \"Commercial Banking\",\n",
+    "        \"owner\": \"commercial_data_team@mapletrust.ca\",\n",
+    "        \"sla\": \"99.0% availability, refreshed daily by 08:00 ET\",\n",
+    "        \"products\": {\n",
+    "            \"commercial_accounts\": {\n",
+    "                \"description\": \"Commercial banking accounts (investment, mortgage)\",\n",
+    "                \"schema\": {\n",
+    "                    \"required_fields\": [\"account_id\", \"customer_id\", \"account_type\", \"status\", \"balance\"],\n",
+    "                    \"types\": {\"account_id\": \"string\", \"customer_id\": \"string\", \"account_type\": \"string\",\n",
+    "                              \"status\": \"string\", \"balance\": \"float\"},\n",
+    "                    \"constraints\": {\"account_type\": [\"investment\", \"mortgage\"]}\n",
+    "                },\n",
+    "                \"freshness\": \"daily\"\n",
+    "            },\n",
+    "            \"commercial_transactions\": {\n",
+    "                \"description\": \"Commercial transaction events\",\n",
+    "                \"schema\": {\n",
+    "                    \"required_fields\": [\"transaction_id\", \"account_id\", \"branch_id\", \"amount\", \"timestamp\"],\n",
+    "                    \"types\": {\"transaction_id\": \"string\", \"account_id\": \"string\", \"branch_id\": \"string\",\n",
+    "                              \"amount\": \"float\", \"timestamp\": \"datetime\"}\n",
+    "                },\n",
+    "                \"freshness\": \"daily\"\n",
+    "            }\n",
+    "        }\n",
+    "    },\n",
+    "    \"risk_compliance\": {\n",
+    "        \"domain\": \"Risk & Compliance\",\n",
+    "        \"owner\": \"risk_data_team@mapletrust.ca\",\n",
+    "        \"sla\": \"99.9% availability, refreshed daily by 05:00 ET\",\n",
+    "        \"products\": {\n",
+    "            \"aml_alerts\": {\n",
+    "                \"description\": \"AML alerts generated by transaction monitoring\",\n",
+    "                \"schema\": {\n",
+    "                    \"required_fields\": [\"alert_id\", \"customer_id\", \"alert_type\", \"risk_level\", \"created_at\"],\n",
+    "                    \"types\": {\"alert_id\": \"string\", \"customer_id\": \"string\", \"alert_type\": \"string\",\n",
+    "                              \"risk_level\": \"string\", \"created_at\": \"datetime\"}\n",
+    "                },\n",
+    "                \"freshness\": \"near-real-time\"\n",
+    "            },\n",
+    "            \"customer_risk_scores\": {\n",
+    "                \"description\": \"ML-derived customer risk scores for AML/KYC\",\n",
+    "                \"schema\": {\n",
+    "                    \"required_fields\": [\"customer_id\", \"risk_score\", \"risk_category\", \"scored_at\"],\n",
+    "                    \"types\": {\"customer_id\": \"string\", \"risk_score\": \"integer\",\n",
+    "                              \"risk_category\": \"string\", \"scored_at\": \"datetime\"},\n",
+    "                    \"constraints\": {\"risk_category\": [\"low\", \"medium\", \"high\", \"very_high\"]}\n",
+    "                },\n",
+    "                \"freshness\": \"daily\"\n",
+    "            }\n",
+    "        }\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "# Write contracts to domain directories\n",
+    "for domain_key, contract in contracts.items():\n",
+    "    contract_path = os.path.join(MESH_DIR, domain_key, \"contract.json\")\n",
+    "    with open(contract_path, \"w\") as f:\n",
+    "        json.dump(contract, f, indent=2)\n",
+    "    print(f\"Published contract: {domain_key} ({len(contract['products'])} data products)\")\n",
+    "\n",
+    "print(\"\\nEach domain owns its data products and publishes a contract.\")\n",
+    "print(\"Consumers discover products via the contract, not by exploring raw files.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Partition and publish data per domain\n",
+    "import numpy as np\n",
+    "\n",
+    "# Retail Banking: retail + wealth customers, chequing/savings/credit accounts\n",
+    "retail_customers = customers_df[customers_df[\"segment\"].isin([\"retail\", \"wealth\"])].copy()\n",
+    "retail_account_types = [\"chequing\", \"savings\", \"credit\"]\n",
+    "retail_accounts = accounts_df[accounts_df[\"account_type\"].isin(retail_account_types)].copy()\n",
+    "retail_acct_ids = set(retail_accounts[\"account_id\"])\n",
+    "retail_transactions = transactions_df[transactions_df[\"account_id\"].isin(retail_acct_ids)].copy()\n",
+    "\n",
+    "retail_customers.to_parquet(os.path.join(MESH_DIR, \"retail_banking\", \"customers.parquet\"))\n",
+    "retail_accounts.to_parquet(os.path.join(MESH_DIR, \"retail_banking\", \"retail_accounts.parquet\"))\n",
+    "retail_transactions.to_parquet(os.path.join(MESH_DIR, \"retail_banking\", \"retail_transactions.parquet\"))\n",
+    "\n",
+    "print(f\"Retail Banking domain:\")\n",
+    "print(f\"  customers:           {len(retail_customers):,}\")\n",
+    "print(f\"  retail_accounts:     {len(retail_accounts):,}\")\n",
+    "print(f\"  retail_transactions: {len(retail_transactions):,}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Commercial Banking: commercial + institutional customers, investment/mortgage accounts\n",
+    "commercial_account_types = [\"investment\", \"mortgage\"]\n",
+    "commercial_accounts = accounts_df[accounts_df[\"account_type\"].isin(commercial_account_types)].copy()\n",
+    "commercial_acct_ids = set(commercial_accounts[\"account_id\"])\n",
+    "commercial_transactions = transactions_df[transactions_df[\"account_id\"].isin(commercial_acct_ids)].copy()\n",
+    "\n",
+    "commercial_accounts.to_parquet(os.path.join(MESH_DIR, \"commercial_banking\", \"commercial_accounts.parquet\"))\n",
+    "commercial_transactions.to_parquet(os.path.join(MESH_DIR, \"commercial_banking\", \"commercial_transactions.parquet\"))\n",
+    "\n",
+    "print(f\"Commercial Banking domain:\")\n",
+    "print(f\"  commercial_accounts:     {len(commercial_accounts):,}\")\n",
+    "print(f\"  commercial_transactions: {len(commercial_transactions):,}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Risk & Compliance: generate synthetic AML alerts and risk scores\n",
+    "np.random.seed(42)\n",
+    "\n",
+    "# Generate AML alerts for high-risk customers\n",
+    "high_risk_customers = customers_df[customers_df[\"risk_score\"] >= 60][\"customer_id\"].values\n",
+    "n_alerts = min(5000, len(high_risk_customers) * 2)\n",
+    "alert_customer_ids = np.random.choice(high_risk_customers, size=n_alerts, replace=True)\n",
+    "\n",
+    "aml_alerts = pd.DataFrame({\n",
+    "    \"alert_id\": [f\"AML-{i+1:06d}\" for i in range(n_alerts)],\n",
+    "    \"customer_id\": alert_customer_ids,\n",
+    "    \"alert_type\": np.random.choice(\n",
+    "        [\"unusual_volume\", \"structuring\", \"high_risk_jurisdiction\", \"sanctions_match\", \"pattern_anomaly\"],\n",
+    "        size=n_alerts\n",
+    "    ),\n",
+    "    \"risk_level\": np.random.choice([\"low\", \"medium\", \"high\", \"critical\"], size=n_alerts, p=[0.3, 0.35, 0.25, 0.1]),\n",
+    "    \"created_at\": pd.date_range(\"2024-01-01\", periods=n_alerts, freq=\"h\"),\n",
+    "})\n",
+    "\n",
+    "# Generate customer risk scores\n",
+    "risk_scores = pd.DataFrame({\n",
+    "    \"customer_id\": customers_df[\"customer_id\"].values,\n",
+    "    \"risk_score\": customers_df[\"risk_score\"].values,\n",
+    "    \"risk_category\": pd.cut(customers_df[\"risk_score\"],\n",
+    "                            bins=[0, 25, 50, 75, 100],\n",
+    "                            labels=[\"low\", \"medium\", \"high\", \"very_high\"]).astype(str),\n",
+    "    \"scored_at\": pd.Timestamp(\"2024-10-01\"),\n",
+    "})\n",
+    "\n",
+    "aml_alerts.to_parquet(os.path.join(MESH_DIR, \"risk_compliance\", \"aml_alerts.parquet\"))\n",
+    "risk_scores.to_parquet(os.path.join(MESH_DIR, \"risk_compliance\", \"customer_risk_scores.parquet\"))\n",
+    "\n",
+    "print(f\"Risk & Compliance domain:\")\n",
+    "print(f\"  aml_alerts:           {len(aml_alerts):,}\")\n",
+    "print(f\"  customer_risk_scores: {len(risk_scores):,}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Show the mesh directory structure\n",
+    "print(\"📊 Reference Architecture Swimlane: Discovery & Exploration\")\n",
+    "print(\"   (IBM Knowledge Catalog — federated domain catalogs)\\n\")\n",
+    "\n",
+    "print(\"Data Mesh directory structure:\")\n",
+    "for domain in domains:\n",
+    "    domain_path = os.path.join(MESH_DIR, domain)\n",
+    "    files = os.listdir(domain_path)\n",
+    "    print(f\"\\n  {domain}/\")\n",
+    "    for f in sorted(files):\n",
+    "        fpath = os.path.join(domain_path, f)\n",
+    "        size = os.path.getsize(fpath) / 1024 / 1024\n",
+    "        print(f\"    {f:40s} {size:>8.1f} MB\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Section 4: Three Canonical Queries"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Connect DuckDB\n",
+    "con = duckdb.connect()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Q1: Total transaction volume by branch for Q3 2024\n",
+    "\n",
+    "Consumer queries the **Retail Banking** domain's data product. Clean, curated, SLA-backed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# First: read the contract to understand what we're consuming\n",
+    "with open(os.path.join(MESH_DIR, \"retail_banking\", \"contract.json\")) as f:\n",
+    "    retail_contract = json.load(f)\n",
+    "\n",
+    "print(\"Data Product Contract — Retail Banking\")\n",
+    "print(f\"  Owner: {retail_contract['owner']}\")\n",
+    "print(f\"  SLA:   {retail_contract['sla']}\")\n",
+    "print(f\"  Products: {list(retail_contract['products'].keys())}\")\n",
+    "print()\n",
+    "print(\"As a consumer, I discover and trust the data through its contract.\")\n",
+    "print(\"I don't need to know HOW it was built — only WHAT it provides.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Query the retail banking domain's transaction product\n",
+    "q1 = con.execute(f\"\"\"\n",
+    "    SELECT\n",
+    "        t.branch_id,\n",
+    "        COUNT(*)           AS txn_count,\n",
+    "        SUM(t.amount)      AS total_amount,\n",
+    "        AVG(t.amount)      AS avg_amount\n",
+    "    FROM '{MESH_DIR}/retail_banking/retail_transactions.parquet' t\n",
+    "    WHERE t.timestamp >= '2024-07-01' AND t.timestamp < '2024-10-01'\n",
+    "    GROUP BY t.branch_id\n",
+    "    ORDER BY total_amount DESC\n",
+    "\"\"\").fetchdf()\n",
+    "\n",
+    "print(\"Q1: Retail transaction volume by branch — Q3 2024 (from Retail Banking domain)\")\n",
+    "print(\"Domain owns and curates this data. Consumer trusts the contract.\")\n",
+    "q1.head(10)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Q2: Cross-domain query — Join Retail (customers) + Risk (AML alerts)\n",
+    "\n",
+    "Consumer needs data from TWO domains. This requires understanding both contracts."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Read both contracts\n",
+    "with open(os.path.join(MESH_DIR, \"risk_compliance\", \"contract.json\")) as f:\n",
+    "    risk_contract = json.load(f)\n",
+    "\n",
+    "print(\"Cross-domain query requires understanding TWO contracts:\")\n",
+    "print()\n",
+    "print(f\"  Domain 1: {retail_contract['domain']}\")\n",
+    "print(f\"    Product: customers\")\n",
+    "print(f\"    Join key: customer_id (string)\")\n",
+    "print()\n",
+    "print(f\"  Domain 2: {risk_contract['domain']}\")\n",
+    "print(f\"    Product: aml_alerts\")\n",
+    "print(f\"    Join key: customer_id (string)\")\n",
+    "print()\n",
+    "print(\"The shared key 'customer_id' is a governance challenge:\")\n",
+    "print(\"  → Who owns the definition of customer_id?\")\n",
+    "print(\"  → What if the domains use different ID formats?\")\n",
+    "print(\"  → This is why federated governance is the hardest mesh principle.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "q2 = con.execute(f\"\"\"\n",
+    "    SELECT\n",
+    "        c.customer_id,\n",
+    "        c.name,\n",
+    "        c.segment,\n",
+    "        c.risk_score AS retail_risk_score,\n",
+    "        a.alert_id,\n",
+    "        a.alert_type,\n",
+    "        a.risk_level,\n",
+    "        a.created_at\n",
+    "    FROM '{MESH_DIR}/retail_banking/customers.parquet' c\n",
+    "    JOIN '{MESH_DIR}/risk_compliance/aml_alerts.parquet' a\n",
+    "        ON c.customer_id = a.customer_id\n",
+    "    WHERE a.risk_level IN ('high', 'critical')\n",
+    "    ORDER BY a.created_at DESC\n",
+    "\"\"\").fetchdf()\n",
+    "\n",
+    "print(f\"Q2: Cross-domain join — Retail customers with high/critical AML alerts\")\n",
+    "print(f\"    Results: {len(q2):,} rows (customers with high/critical alerts)\")\n",
+    "q2.head(10)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Q3: Lineage — within-domain vs. cross-domain\n",
+    "\n",
+    "Each domain owns its own lineage. Cross-domain lineage is the hard problem."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Within-domain lineage: Risk & Compliance knows exactly how AML alerts are built\n",
+    "print(\"Q3: Lineage\")\n",
+    "print(\"=\"*60)\n",
+    "print()\n",
+    "print(\"WITHIN-DOMAIN lineage (Risk & Compliance):\")\n",
+    "print(\"  raw.transactions → curated.transactions_clean → consumed.aml_alerts\")\n",
+    "print(\"  raw.customers → curated.customer_360 → consumed.aml_alerts\")\n",
+    "print(\"  raw.wire_transfers → curated.wire_transfers_enriched → consumed.aml_alerts\")\n",
+    "print(\"  curated.sanctions_reference → consumed.aml_alerts\")\n",
+    "print()\n",
+    "print(\"  ✅ The Risk domain knows exactly how its alerts are produced.\")\n",
+    "print(\"     It owns the pipeline, the data, and the lineage.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Cross-domain lineage: the hard problem\n",
+    "with open(LINEAGE_PATH) as f:\n",
+    "    lineage = json.load(f)\n",
+    "\n",
+    "print(\"\\nCROSS-DOMAIN lineage (the hard problem):\")\n",
+    "print()\n",
+    "print(\"  Our Q2 query joins:\")\n",
+    "print(\"    Retail Banking → customers (owned by retail_data_team)\")\n",
+    "print(\"    Risk & Compliance → aml_alerts (owned by risk_data_team)\")\n",
+    "print()\n",
+    "print(\"  Questions no single domain can answer:\")\n",
+    "print(\"    → What is the full lineage of Q2's result?\")\n",
+    "print(\"    → If retail changes their customer_id format, who breaks?\")\n",
+    "print(\"    → If risk changes their alert thresholds, does retail know?\")\n",
+    "print()\n",
+    "print(\"  This requires a FEDERATED CATALOG that spans domains.\")\n",
+    "print(\"  → IBM Knowledge Catalog provides this in the IBM stack.\")\n",
+    "print()\n",
+    "\n",
+    "# Show the portion of the lineage graph relevant to aml_alerts\n",
+    "target = \"consumed.aml_alerts\"\n",
+    "upstream_edges = [e for e in lineage[\"edges\"] if e[\"to\"] == target]\n",
+    "print(f\"Lineage graph edges into {target}:\")\n",
+    "for edge in upstream_edges:\n",
+    "    node = next((n for n in lineage[\"nodes\"] if n[\"id\"] == edge[\"from\"]), None)\n",
+    "    owner = node[\"owner\"] if node else \"unknown\"\n",
+    "    print(f\"  ← {edge['from']:40s} (owner: {owner})\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Section 5: Where This Pattern Breaks"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Break 1: Domains don't invest in data quality\n",
+    "\n",
+    "A data product that violates its own contract."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create a \"bad\" data product that violates its contract\n",
+    "bad_product = pd.DataFrame({\n",
+    "    \"customer_id\": [\"CUST-000001\", None, \"CUST-000003\", \"CUST-INVALID\", \"CUST-000005\"],\n",
+    "    \"name\": [\"Alice\", \"Bob\", None, \"Diana\", \"Eve\"],                  # missing name\n",
+    "    # 'segment' is REQUIRED by contract — but missing entirely\n",
+    "    # 'kyc_status' is REQUIRED by contract — but missing entirely\n",
+    "    \"risk_score\": [25, -5, 50, 200, None],                            # invalid values\n",
+    "})\n",
+    "\n",
+    "print(\"A 'bad' data product from a domain that didn't invest in quality:\")\n",
+    "print(bad_product)\n",
+    "print()\n",
+    "print(\"Contract violations:\")\n",
+    "print(\"  ✗ customer_id has NULL (row 2)\")\n",
+    "print(\"  ✗ name has NULL (row 3)\")\n",
+    "print(\"  ✗ 'segment' field is MISSING (required by contract)\")\n",
+    "print(\"  ✗ 'kyc_status' field is MISSING (required by contract)\")\n",
+    "print(\"  ✗ risk_score = -5 (must be 1-100)\")\n",
+    "print(\"  ✗ risk_score = 200 (must be 1-100)\")\n",
+    "print(\"  ✗ risk_score = NULL (must be integer)\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Validate against contract\n",
+    "contract = contracts[\"retail_banking\"][\"products\"][\"customers\"]\n",
+    "required_fields = contract[\"schema\"][\"required_fields\"]\n",
+    "actual_fields = list(bad_product.columns)\n",
+    "\n",
+    "print(\"Contract validation:\")\n",
+    "print(f\"  Required fields: {required_fields}\")\n",
+    "print(f\"  Actual fields:   {actual_fields}\")\n",
+    "print()\n",
+    "\n",
+    "missing = set(required_fields) - set(actual_fields)\n",
+    "if missing:\n",
+    "    print(f\"  FAILED: Missing required fields: {missing}\")\n",
+    "\n",
+    "# Check nulls in required fields\n",
+    "for col in actual_fields:\n",
+    "    if col in required_fields and bad_product[col].isna().any():\n",
+    "        null_count = bad_product[col].isna().sum()\n",
+    "        print(f\"  FAILED: '{col}' has {null_count} NULL(s) — contract requires non-null\")\n",
+    "\n",
+    "print()\n",
+    "print(\"⚠️  Without enforcement, contracts are just documentation.\")\n",
+    "print(\"   Data mesh assumes domains WILL invest in quality.\")\n",
+    "print(\"   When they don't, consumers get garbage with a nice label.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Break 2: Cross-domain queries with no shared keys"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# What if commercial banking uses a different customer ID format?\n",
+    "print(\"Break 2: Cross-domain join with incompatible keys\")\n",
+    "print(\"=\"*60)\n",
+    "print()\n",
+    "print(\"Scenario: Retail uses customer_id = 'CUST-000001'\")\n",
+    "print(\"          Commercial uses client_ref = 'CL-MTB-000001'\")\n",
+    "print(\"          Risk uses entity_id = 'ENT-000001'\")\n",
+    "print()\n",
+    "print(\"Each domain chose its own identifier scheme.\")\n",
+    "print(\"There is no global entity resolution.\")\n",
+    "print(\"Cross-domain joins produce ZERO results or require MDM.\")\n",
+    "print()\n",
+    "print(\"This is the #1 failure mode of data mesh:\")\n",
+    "print(\"  Domains are autonomous — but autonomy without standards = chaos.\")\n",
+    "print(\"  Federated governance MUST include shared key standards.\")\n",
+    "print(\"  → IBM Master Data Management (MDM) solves entity resolution.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Break 3: Federated governance — theory vs. practice"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"Break 3: Federated governance in practice\")\n",
+    "print(\"=\"*60)\n",
+    "print()\n",
+    "print(\"Theory:\")\n",
+    "print(\"  → Each domain enforces global policies locally\")\n",
+    "print(\"  → A governance council sets standards\")\n",
+    "print(\"  → Automated compliance checks run at publish time\")\n",
+    "print()\n",
+    "print(\"Practice:\")\n",
+    "print(\"  → The governance council meets quarterly (if that)\")\n",
+    "print(\"  → Standards exist in a wiki no one reads\")\n",
+    "print(\"  → Domains skip quality checks when under deadline pressure\")\n",
+    "print(\"  → PII leaks across domain boundaries via join keys\")\n",
+    "print(\"  → No one owns cross-domain data quality\")\n",
+    "print()\n",
+    "print('\"Data mesh is the right answer for orgs with 500+ data engineers')\n",
+    "print('and strong product culture. For everyone else, it\\'s a conference')\n",
+    "print('talk that became a reorg.\"')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Section 6: The IBM Stack Mapping\n",
+    "\n",
+    "| Component | IBM Product | Swimlane |\n",
+    "|-----------|-------------|----------|\n",
+    "| Federated Catalog | IBM Knowledge Catalog (per-domain catalogs) | Discovery & Exploration |\n",
+    "| Self-Serve Platform | watsonx.data (domain-level compute) | Analytical Data Management & Storage |\n",
+    "| Data Quality | IBM Data Quality (automated contract validation) | Information & Model Management & Governance |\n",
+    "| Business Glossary | IBM Business Glossary (shared terms across domains) | Information & Model Management & Governance |\n",
+    "| Data Product APIs | IBM API Connect (publish data products as APIs) | Data Access |\n",
+    "| Entity Resolution | IBM Match 360 / MDM (shared key management) | Information & Model Management & Governance |\n",
+    "\n",
+    "**Swimlane:** Discovery & Exploration — IBM Knowledge Catalog is the federated catalog layer.\n",
+    "\n",
+    "**Note:** \"IBM doesn't sell 'data mesh.' IBM sells the platform that makes mesh possible — if your org is ready.\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"📊 Reference Architecture Swimlane: Discovery & Exploration\")\n",
+    "print(\"   (IBM Knowledge Catalog — federated domain catalogs)\\n\")\n",
+    "print(\"IBM Product Mapping:\")\n",
+    "print(\"  Federated Catalog  → IBM Knowledge Catalog (per-domain catalogs)\")\n",
+    "print(\"  Self-Serve Platform → watsonx.data (domain-level compute)\")\n",
+    "print(\"  Data Quality       → IBM Data Quality (contract validation)\")\n",
+    "print(\"  Business Glossary  → IBM Business Glossary (shared terms)\")\n",
+    "print(\"  Data Product APIs  → IBM API Connect\")\n",
+    "print(\"  Entity Resolution  → IBM Match 360 / MDM\")\n",
+    "print()\n",
+    "print(\"IBM doesn't sell 'data mesh.'\")\n",
+    "print(\"IBM sells the platform that makes mesh possible — if your org is ready.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Section 7: BFSI Reality Check\n",
+    "\n",
+    "No Canadian bank has fully implemented data mesh. Several have adopted elements: RBC has domain-oriented data teams aligned to lines of business, Scotiabank has invested in data product catalogs, and TD has experimented with self-serve data platforms. The pattern works at the edges — a single domain (say, credit risk) that owns its data end-to-end and publishes curated products for downstream consumers. Where it fails: cross-domain use cases like enterprise-wide customer 360, where you need retail, commercial, wealth, and insurance data joined together. The shared key problem (\"what is a customer?\") becomes existential. The banks that succeed with mesh are the ones that start with one domain, prove the model, and grow organically. The ones that fail try to mesh everything at once — reorging the data team into domains without changing the culture, tooling, or incentives. That's not mesh; that's chaos with a Zhamak citation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Clean up\n",
+    "con.close()\n",
+    "print(\"Notebook 5 complete.\")\n",
+    "print()\n",
+    "print(\"Key takeaway: Data mesh is an organizational pattern, not a technology.\")\n",
+    "print(\"It works when domains own their data as products with enforceable contracts.\")\n",
+    "print(\"It fails when governance is federated in theory but absent in practice.\")\n",
+    "print(\"Next: Notebook 6 (RAG) — finally answering Q2 with AI.\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
## Summary
- **Notebook 2** (Data Lake): MinIO + DuckDB on raw Parquet, governance gap demo
- **Notebook 3** (Lakehouse): PyIceberg + DuckDB, schema evolution/time travel/partition pruning — **live in Block 4**
- **Notebook 4** (Virtualization): DuckDB postgres_scanner federation — **cameo in Block 1**
- **Notebook 5** (Data Mesh): 3 simulated domains with JSON schema contracts, honest caveat

All follow the 7-section template from NB1.

Closes #7, closes #8, closes #9, closes #10

## Test plan
- [ ] Each notebook is valid JSON (`python -m json.tool notebooks/0X-*.ipynb`)
- [ ] NB3 runs in ~15 min for live demo
- [ ] NB4 Q1 runs in ~3 min for cameo

🤖 Generated with [Claude Code](https://claude.com/claude-code)