### PR TITLE
Fix NB3 Iceberg null type error + add pyiceberg to deps

### DIFF
--- a/notebooks/03-lakehouse.ipynb
+++ b/notebooks/03-lakehouse.ipynb
@@ -432,24 +432,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# Add more data to create a new snapshot\n",
-    "new_txns = pa.table({\n",
-    "    \"transaction_id\": [f\"TXN-NEW-{i:06d}\" for i in range(1000)],\n",
-    "    \"account_id\": [f\"ACCT-{(i % 200000) + 1:06d}\" for i in range(1000)],\n",
-    "    \"branch_id\": [f\"MTB-{(i % 50) + 1:03d}\" for i in range(1000)],\n",
-    "    \"amount\": [float(100 + i) for i in range(1000)],\n",
-    "    \"currency\": [\"CAD\"] * 1000,\n",
-    "    \"timestamp\": pd.to_datetime([\"2024-12-01\"] * 1000),\n",
-    "    \"transaction_type\": [\"deposit\"] * 1000,\n",
-    "    \"channel\": [\"online\"] * 1000,\n",
-    "    \"counterparty_id\": [None] * 1000,\n",
-    "})\n",
-    "\n",
-    "txn_table = catalog.load_table(\"bfsi.transactions\")\n",
-    "txn_table.append(new_txns)\n",
-    "print(\"Added 1,000 new transactions (snapshot 2 created)\")"
-   ]
+   "source": "# Add more data to create a new snapshot\nnew_txns = pa.table({\n    \"transaction_id\": [f\"TXN-NEW-{i:06d}\" for i in range(1000)],\n    \"account_id\": [f\"ACCT-{(i % 200000) + 1:06d}\" for i in range(1000)],\n    \"branch_id\": [f\"MTB-{(i % 50) + 1:03d}\" for i in range(1000)],\n    \"amount\": [float(100 + i) for i in range(1000)],\n    \"currency\": [\"CAD\"] * 1000,\n    \"timestamp\": pd.to_datetime([\"2024-12-01\"] * 1000),\n    \"transaction_type\": [\"deposit\"] * 1000,\n    \"channel\": [\"online\"] * 1000,\n    \"counterparty_id\": pa.array([\"EXTERNAL-0000\"] * 1000, type=pa.string()),\n})\n\ntxn_table = catalog.load_table(\"bfsi.transactions\")\ntxn_table.append(new_txns)\nprint(\"Added 1,000 new transactions (snapshot 2 created)\")"
   },
   {
    "cell_type": "code",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,8 @@ dependencies = [
     "psycopg2-binary",
     "trino",
     "sqlalchemy",
+    # Lakehouse
+    "pyiceberg",
     # Object storage
     "minio",
     # Search


### PR DESCRIPTION
## Summary
- Fix `ValueError: Null type (pa.null()) is not supported in Iceberg format version 2` in NB3 time-travel cell — `counterparty_id` was `[None] * 1000` (inferred as null type), now uses `pa.array(["EXTERNAL-0000"] * 1000, type=pa.string())`
- Add `pyiceberg` to `pyproject.toml` dependencies (was missing, NB3 requires it)

## Test plan
- [x] `jupyter nbconvert --execute notebooks/03-lakehouse.ipynb` passes
- [x] All 5 notebooks pass headless execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)