### PR TITLE
fix: timeline arrows on slide 6 going off-screen

### DIFF
--- a/deck/generate_deck.py
+++ b/deck/generate_deck.py
@@ -813,7 +813,7 @@ def make_slide_06_reinvention(prs):
                 slide,
                 x + box_w,
                 y + Inches(0.1),
-                Inches(gap),
+                gap,  # already in EMU from Inches(0.25)
                 Inches(0.5),
                 "\u2192",
                 font_name=FONT_BODY,


### PR DESCRIPTION
## Summary
Fix `Inches(gap)` double-conversion bug in slide 6 (30-year arc timeline). `gap` was already in EMU from `Inches(0.25)`, but `Inches()` treated the EMU value (228600) as inches, creating 228600-inch-wide arrow text boxes that went massively off-screen.

One-line fix: `Inches(gap)` → `gap`

## Test plan
- [ ] `python deck/generate_deck.py` and open the PPTX
- [ ] Slide 6: verify all 5 arrow symbols (→) are visible between timeline boxes

🤖 Generated with [Claude Code](https://claude.com/claude-code)