### PR TITLE
feat: notebook stylesheet + expanded design tokens from Claude Design

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,13 @@
 
 .DEFAULT_GOAL := help
 
-.PHONY: help install-dev setup generate-data run-notebooks smoke-test validate clean docker-up docker-down lint pre-commit
+.PHONY: help install-dev setup generate-data generate-deck run-notebooks smoke-test validate clean docker-up docker-down lint pre-commit
 
 # help:
 # help: 🎯 QUICK START
 # help: setup              Install deps + start Docker services
 # help: generate-data      Generate synthetic BFSI data
+# help: generate-deck      Generate the PPTX deck
 # help:
 # help: 🐍 PYTHON
 # help: install-dev        Install Python dev dependencies (no Docker)
@@ -36,6 +37,9 @@ setup: install-dev docker-up
 
 generate-data:
 	python data/generate.py
+
+generate-deck:
+	python deck/generate_deck.py
 
 install-dev:
 	@test -d .venv || (echo "Creating .venv..." && uv venv .venv)

--- a/deck/generate_deck.py
+++ b/deck/generate_deck.py
@@ -7,14 +7,20 @@ Usage:
 Output:
     deck/data-architecture-ai-era.pptx
 
-Design system:
+Design system (aligned with Claude Design lecture template):
     Canvas  : 16:9 widescreen (13.333" x 7.5")
     Bg      : #F4F2EC (paper) on ALL slides — light theme, non-negotiable
+    BgAlt   : #EAE7DF (paper-alt, used for stat/reality-check slides)
     Accent  : #2D4ADE (signal blue)
+    Accent2 : #1A2C8C (deep blue, for secondary accents)
     Ink     : #15171A (primary text)
     Ink2    : #3A3F47 (secondary text)
     Slate   : #5C6470 (tertiary / mono labels)
+    Slate2  : #8A93A0 (quaternary)
     Rule    : #C9C4B6 (hairlines / borders)
+    RuleSoft: #DCD7C8 (softer hairlines)
+    Grid    : #E1DCCB (blueprint grid background)
+    Warn    : #B85C00 (ochre — errors, warnings)
     Fonts   : Georgia (display/titles), Calibri (body), Consolas (mono/code)
 """
 
@@ -31,12 +37,30 @@ from pptx.util import Inches, Pt
 # ── Design tokens ──────────────────────────────────────────────────────────────
 
 PAPER = RGBColor(0xF4, 0xF2, 0xEC)
+PAPER_ALT = RGBColor(0xEA, 0xE7, 0xDF)
 ACCENT = RGBColor(0x2D, 0x4A, 0xDE)
+ACCENT2 = RGBColor(0x1A, 0x2C, 0x8C)
 INK = RGBColor(0x15, 0x17, 0x1A)
 INK2 = RGBColor(0x3A, 0x3F, 0x47)
 SLATE = RGBColor(0x5C, 0x64, 0x70)
+SLATE2 = RGBColor(0x8A, 0x93, 0xA0)
 RULE = RGBColor(0xC9, 0xC4, 0xB6)
+RULE_SOFT = RGBColor(0xDC, 0xD7, 0xC8)
+GRID = RGBColor(0xE1, 0xDC, 0xCB)
+WARN = RGBColor(0xB8, 0x5C, 0x00)
 WHITE = RGBColor(0xFF, 0xFF, 0xFF)
+
+# ── Ref-arch lane palette (from Claude Design template) ───────────────────────
+
+LANE_PALETTE = {
+    "insight": {"bar": RGBColor(0x1A, 0x2C, 0x8C), "chip": RGBColor(0xE4, 0xE7, 0xF7)},
+    "motion": {"bar": RGBColor(0x0E, 0x5E, 0x5C), "chip": RGBColor(0xDE, 0xEA, 0xE9)},
+    "storage": {"bar": RGBColor(0x2D, 0x4A, 0xDE), "chip": RGBColor(0xE0, 0xE6, 0xFB)},
+    "ingestion": {"bar": RGBColor(0x5B, 0x3F, 0xB8), "chip": RGBColor(0xE8, 0xE2, 0xF5)},
+    "sources": {"bar": RGBColor(0x3A, 0x3F, 0x47), "chip": RGBColor(0xE5, 0xE3, 0xDA)},
+    "governance": {"bar": RGBColor(0xB8, 0x5C, 0x00), "chip": RGBColor(0xF2, 0xE4, 0xD2)},
+    "deploy": {"bar": RGBColor(0x15, 0x17, 0x1A), "chip": RGBColor(0xE5, 0xE3, 0xDA)},
+}
 
 SLIDE_W = Inches(13.333)
 SLIDE_H = Inches(7.5)

--- a/deck/generate_pattern_diagrams.py
+++ b/deck/generate_pattern_diagrams.py
@@ -585,9 +585,7 @@ def gen_lake() -> None:
         anchor="middle",
         weight="bold",
     )
-    _text(
-        dwg, "for Cognos", wh_x + wh_w / 2, wh_y + 195, font_size=14, fill=SLATE, anchor="middle"
-    )
+    _text(dwg, "for Cognos", wh_x + wh_w / 2, wh_y + 195, font_size=14, fill=SLATE, anchor="middle")
     _text(
         dwg,
         "(duplicate of lake data)",
@@ -1064,9 +1062,7 @@ def gen_fabric() -> None:
             anchor="middle",
             weight="bold",
         )
-        _text(
-            dwg, sub, cx, estate_y + 60, font_size=13, fill=SLATE, anchor="middle", font_family=FONT_SANS
-        )
+        _text(dwg, sub, cx, estate_y + 60, font_size=13, fill=SLATE, anchor="middle", font_family=FONT_SANS)
         for j in range(3):
             _box(dwg, sx + 28, estate_y + 90 + j * 32, store_w - 56, 24, fill=WHITE, rx=2)
         _arrow(dwg, cx, fab_y + fab_h, cx, estate_y, color=ACCENT, width=2, marker_id=f"a-f-s{cx}")
@@ -1108,9 +1104,7 @@ def gen_fabric() -> None:
         ],
     )
 
-    _draw_tagline(
-        dwg, '"The metadata layer that knows where everything is. Architectural style, not a place."'
-    )
+    _draw_tagline(dwg, '"The metadata layer that knows where everything is. Architectural style, not a place."')
     _save(dwg)
 
 
@@ -1278,9 +1272,7 @@ def gen_mesh() -> None:
     ]
     for i, item in enumerate(plat_items):
         ix = start_x + 60 + i * (total_w - 120) / (len(plat_items) - 1)
-        _text(
-            dwg, item, ix, plat_y + 78, font_size=14, fill=ACCENT_LIGHT, anchor="middle", font_family=FONT_SANS
-        )
+        _text(dwg, item, ix, plat_y + 78, font_size=14, fill=ACCENT_LIGHT, anchor="middle", font_family=FONT_SANS)
 
     # Arrows to platform
     for i in range(len(domains)):

--- a/notebooks/notebook-style.css
+++ b/notebooks/notebook-style.css
@@ -1,0 +1,269 @@
+/* notebook-style.css — Drop-in style for Jupyter notebooks rendered for the
+   "Data Architecture for the AI Era" lecture series. Copy to ~/.jupyter/custom/custom.css
+   or import from a Quarto/HTML render pipeline.
+
+   Uses the same design tokens as the PPTX deck:
+   paper #F4F2EC, ink #15171A, accent #2D4ADE.
+   Source Serif 4 (display), Inter (body), JetBrains Mono (code). */
+
+@import url('https://fonts.googleapis.com/css2?family=Source+Serif+4:ital,wght@0,400;0,600;1,400&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap');
+
+:root {
+  --fg-paper:    #F4F2EC;
+  --fg-paper-alt:#EAE7DF;
+  --fg-ink:      #15171A;
+  --fg-ink2:     #3A3F47;
+  --fg-slate:    #5C6470;
+  --fg-rule:     #C9C4B6;
+  --fg-accent:   #2D4ADE;
+  --fg-warn:     #B85C00;
+
+  --fg-display:  "Source Serif 4", Georgia, serif;
+  --fg-body:     "Inter", "Helvetica Neue", sans-serif;
+  --fg-mono:     "JetBrains Mono", ui-monospace, monospace;
+}
+
+/* ── Notebook page ─────────────────────────────────────────────── */
+.jp-Notebook,
+body.jp-Notebook,
+.jp-NotebookPanel-notebook {
+  background: var(--fg-paper) !important;
+  font-family: var(--fg-body);
+  color: var(--fg-ink);
+  line-height: 1.55;
+}
+
+.jp-Cell { padding: 8px 60px; max-width: 1080px; margin: 0 auto; }
+
+/* ── Markdown cells ────────────────────────────────────────────── */
+.jp-MarkdownOutput,
+.jp-RenderedMarkdown {
+  font-family: var(--fg-body);
+  font-size: 17px;
+  color: var(--fg-ink2);
+  max-width: 800px;
+}
+.jp-RenderedMarkdown p { margin: 0 0 1.1em; line-height: 1.55; text-wrap: pretty; }
+
+.jp-RenderedMarkdown h1 {
+  font-family: var(--fg-display);
+  font-weight: 400;
+  font-size: 56px;
+  line-height: 1.05;
+  letter-spacing: -0.015em;
+  color: var(--fg-ink);
+  margin: 56px 0 18px;
+}
+.jp-RenderedMarkdown h1::after {
+  content: "";
+  display: block;
+  width: 80px;
+  height: 2px;
+  background: var(--fg-ink);
+  margin: 22px 0 0;
+}
+
+.jp-RenderedMarkdown h2 {
+  font-family: var(--fg-display);
+  font-weight: 400;
+  font-size: 34px;
+  line-height: 1.15;
+  letter-spacing: -0.012em;
+  color: var(--fg-ink);
+  margin: 48px 0 14px;
+  padding-top: 28px;
+  border-top: 1px solid var(--fg-rule);
+}
+
+/* Section eyebrow — drop "## Section 1: Title" → eyebrow + title */
+.jp-RenderedMarkdown h2 small,
+.jp-RenderedMarkdown h2 .eyebrow {
+  display: block;
+  font-family: var(--fg-mono);
+  font-size: 13px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--fg-accent);
+  margin-bottom: 10px;
+  font-weight: 500;
+}
+
+.jp-RenderedMarkdown h3 {
+  font-family: var(--fg-display);
+  font-weight: 400;
+  font-size: 24px;
+  margin: 32px 0 10px;
+  color: var(--fg-ink);
+}
+
+/* ── Blockquote → field-guide callout ──────────────────────────── */
+.jp-RenderedMarkdown blockquote {
+  border: none;
+  border-top: 1px solid var(--fg-rule);
+  padding: 22px 0 0 180px;
+  margin: 28px 0;
+  position: relative;
+  font-family: var(--fg-display);
+  font-style: italic;
+  font-size: 19px;
+  line-height: 1.45;
+  color: var(--fg-ink2);
+}
+.jp-RenderedMarkdown blockquote::before {
+  content: "NOTE →";
+  position: absolute;
+  left: 0; top: 22px;
+  font-family: var(--fg-mono);
+  font-style: normal;
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  color: var(--fg-accent);
+}
+
+/* ── Inline + block code ───────────────────────────────────────── */
+.jp-RenderedMarkdown code,
+code {
+  font-family: var(--fg-mono);
+  font-size: 0.92em;
+  background: var(--fg-paper-alt);
+  padding: 1px 6px;
+  border: 1px solid var(--fg-rule);
+}
+
+/* ── Code input cells ──────────────────────────────────────────── */
+.jp-CodeCell .jp-InputArea-editor,
+.jp-CodeCell .jp-Editor,
+.CodeMirror {
+  font-family: var(--fg-mono) !important;
+  font-size: 14px !important;
+  background: var(--fg-paper) !important;
+  border: 1px solid var(--fg-rule) !important;
+  border-radius: 0 !important;
+}
+
+.jp-InputPrompt,
+.jp-OutputPrompt {
+  font-family: var(--fg-mono);
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--fg-slate);
+}
+
+/* ── Output cells ──────────────────────────────────────────────── */
+.jp-OutputArea-output,
+.jp-RenderedHTMLCommon {
+  background: var(--fg-paper-alt);
+  border: 1px solid var(--fg-rule);
+  border-top: none;
+  font-family: var(--fg-mono);
+  font-size: 14px;
+  color: var(--fg-ink);
+  padding: 16px 22px;
+}
+
+/* DataFrame tables */
+.jp-RenderedHTMLCommon table {
+  border-collapse: collapse;
+  width: 100%;
+  font-family: var(--fg-mono);
+  font-size: 13px;
+}
+.jp-RenderedHTMLCommon thead th {
+  text-align: left;
+  border-bottom: 1px solid var(--fg-rule);
+  padding: 10px 14px;
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--fg-slate);
+  font-weight: 500;
+  background: transparent;
+}
+.jp-RenderedHTMLCommon tbody td {
+  padding: 8px 14px;
+  border-bottom: 1px solid var(--fg-rule);
+  color: var(--fg-ink);
+}
+.jp-RenderedHTMLCommon tbody tr:hover { background: rgba(45,74,222,0.04); }
+
+/* Stream output (prints) */
+.jp-OutputArea-output pre {
+  background: transparent;
+  font-family: var(--fg-mono);
+  font-size: 13px;
+  color: var(--fg-ink2);
+  white-space: pre-wrap;
+}
+
+/* Errors are warm-ochre, not red — matches the palette */
+.jp-OutputArea-output[data-mime-type="application/vnd.jupyter.stderr"],
+.jp-OutputArea-output.jp-OutputArea-stderr {
+  background: rgba(184,92,0,0.06);
+  border-left: 3px solid var(--fg-warn);
+  color: var(--fg-warn);
+}
+
+/* ── "Where it breaks" callout — apply via markdown class .breaks ── */
+.jp-RenderedMarkdown .breaks {
+  border: 1px solid var(--fg-ink);
+  padding: 24px 28px;
+  position: relative;
+  margin: 36px 0;
+  font-family: var(--fg-display);
+  font-size: 22px;
+  line-height: 1.25;
+  color: var(--fg-ink);
+}
+.jp-RenderedMarkdown .breaks::before {
+  content: "§ 05 — Where it breaks";
+  position: absolute;
+  top: -11px; left: 18px;
+  background: var(--fg-paper);
+  padding: 0 10px;
+  font-family: var(--fg-mono);
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--fg-ink);
+  font-style: normal;
+}
+
+/* ── Tables in markdown (use-when / don't tables) ──────────────── */
+.jp-RenderedMarkdown table {
+  border-collapse: collapse;
+  margin: 24px 0;
+  font-size: 16px;
+}
+.jp-RenderedMarkdown th {
+  text-align: left;
+  font-family: var(--fg-mono);
+  font-size: 12px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--fg-slate);
+  border-bottom: 2px solid var(--fg-ink);
+  padding: 10px 16px;
+  font-weight: 500;
+}
+.jp-RenderedMarkdown td {
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--fg-rule);
+  vertical-align: top;
+}
+.jp-RenderedMarkdown td:first-child { color: var(--fg-accent); font-family: var(--fg-mono); font-size: 14px; }
+
+/* ── Horizontal rule → chapter break ───────────────────────────── */
+.jp-RenderedMarkdown hr {
+  border: none;
+  height: 1px;
+  background: var(--fg-rule);
+  margin: 48px 0;
+}
+
+/* ── Print: tighter, ink-on-paper ──────────────────────────────── */
+@media print {
+  :root { --fg-paper: #ffffff; --fg-paper-alt: #f6f4ee; }
+  .jp-Cell { break-inside: avoid; }
+  .jp-RenderedMarkdown h1, .jp-RenderedMarkdown h2 { break-after: avoid; }
+}

--- a/tests/test_data_generation.py
+++ b/tests/test_data_generation.py
@@ -61,9 +61,9 @@ class TestParquetFiles:
             pytest.skip(f"{filename} not generated yet")
         df = pd.read_parquet(path)
         spec = PARQUET_FILES[filename]
-        assert (
-            spec["min_rows"] <= len(df) <= spec["max_rows"]
-        ), f"{filename}: row count {len(df)} outside [{spec['min_rows']}, {spec['max_rows']}]"
+        assert spec["min_rows"] <= len(df) <= spec["max_rows"], (
+            f"{filename}: row count {len(df)} outside [{spec['min_rows']}, {spec['max_rows']}]"
+        )
 
     @pytest.mark.parametrize("filename", list(PARQUET_FILES.keys()))
     def test_expected_columns(self, filename: str) -> None:

--- a/tests/test_data_generation.py
+++ b/tests/test_data_generation.py
@@ -61,9 +61,9 @@ class TestParquetFiles:
             pytest.skip(f"{filename} not generated yet")
         df = pd.read_parquet(path)
         spec = PARQUET_FILES[filename]
-        assert spec["min_rows"] <= len(df) <= spec["max_rows"], (
-            f"{filename}: row count {len(df)} outside [{spec['min_rows']}, {spec['max_rows']}]"
-        )
+        assert (
+            spec["min_rows"] <= len(df) <= spec["max_rows"]
+        ), f"{filename}: row count {len(df)} outside [{spec['min_rows']}, {spec['max_rows']}]"
 
     @pytest.mark.parametrize("filename", list(PARQUET_FILES.keys()))
     def test_expected_columns(self, filename: str) -> None:

--- a/tests/test_deck.py
+++ b/tests/test_deck.py
@@ -26,7 +26,11 @@ DECK_PATH = Path(__file__).resolve().parent.parent / "deck" / "data-architecture
 # ── Design tokens from SPEC.md §3 / generate_deck.py ────────────────────────
 
 PAPER = RGBColor(0xF4, 0xF2, 0xEC)
+PAPER_ALT = RGBColor(0xEA, 0xE7, 0xDF)
 ACCENT = RGBColor(0x2D, 0x4A, 0xDE)
+
+# Both paper tones are acceptable light backgrounds
+ALLOWED_BACKGROUNDS = {PAPER, PAPER_ALT}
 
 ALLOWED_FONTS = {"Georgia", "Calibri", "Consolas"}
 
@@ -135,8 +139,8 @@ class TestLightTheme:
         violations: list[str] = []
         for idx, slide in enumerate(deck.slides, 1):
             bg = _slide_bg_color(slide)
-            if bg is not None and bg != PAPER:
-                violations.append(f"Slide {idx}: background #{bg} (expected #{PAPER})")
+            if bg is not None and bg not in ALLOWED_BACKGROUNDS:
+                violations.append(f"Slide {idx}: background #{bg} (expected #{PAPER} or #{PAPER_ALT})")
         assert not violations, "Non-paper backgrounds found:\n" + "\n".join(violations)
 
 

--- a/tests/test_deck.py
+++ b/tests/test_deck.py
@@ -181,9 +181,9 @@ class TestForbiddenTerms:
     def test_no_mistry_surname(self, deck: Presentation) -> None:
         """SPEC.md §8 rule 4: Manav's surname is Gupta, not Mistry."""
         full_text = _all_text_in_deck(deck)
-        assert FORBIDDEN_SURNAME.lower() not in full_text.lower(), (
-            f"Found '{FORBIDDEN_SURNAME}' in deck — Manav's surname must be Gupta"
-        )
+        assert (
+            FORBIDDEN_SURNAME.lower() not in full_text.lower()
+        ), f"Found '{FORBIDDEN_SURNAME}' in deck — Manav's surname must be Gupta"
 
 
 class TestDesignTokens:

--- a/tests/test_notebook_structure.py
+++ b/tests/test_notebook_structure.py
@@ -117,9 +117,9 @@ class TestNotebookStructure:
         md_cells = _markdown_cells(nb)
         assert md_cells, f"{notebook_name}: no markdown cells found"
         first_md = md_cells[0].strip()
-        assert first_md.startswith("# "), (
-            f"{notebook_name}: first markdown cell should be an H1 title, got: {first_md[:80]!r}"
-        )
+        assert first_md.startswith(
+            "# "
+        ), f"{notebook_name}: first markdown cell should be an H1 title, got: {first_md[:80]!r}"
 
     def test_all_seven_sections_present(self, notebook_name: str) -> None:
         """All 7 required sections must appear as markdown headings."""


### PR DESCRIPTION
## Summary
Implements the immediately-shippable artifacts from the Claude Design lecture template handoff:

- **`notebooks/notebook-style.css`** — Drop-in JupyterLab stylesheet matching the deck's design tokens. Copy to `~/.jupyter/custom/custom.css`. Features: Source Serif 4 / Inter / JetBrains Mono typography, field-guide blockquote callouts, styled DataFrame tables, ochre error styling, print mode.
- **Expanded deck design tokens** in `generate_deck.py` — `PAPER_ALT`, `ACCENT2`, `SLATE2`, `RULE_SOFT`, `GRID`, `WARN`, and `LANE_PALETTE` (color-coded ref-arch swimlane colors: indigo/teal/blue/violet/slate/ochre/black)
- **Updated `test_deck.py`** — accepts `PAPER_ALT` (#EAE7DF) as a valid light background for stat/reality-check slides

Full deck layout refresh (crosshairs, section dividers, FieldGuideHeader, etc.) tracked in #41.

## Test plan
- [x] `pytest tests/test_deck.py tests/test_notebook_structure.py -v` — 45 passed
- [x] `ruff check` passes on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)